### PR TITLE
Refactor Map modules and classes

### DIFF
--- a/d_rats/map/__init__.py
+++ b/d_rats/map/__init__.py
@@ -1,4 +1,8 @@
 '''Package to handle Maps for D-Rats.'''
 
-from .mapwindow import MapWindow as Window
+from .mapbottompanel import MapBottomPanel as BottomPanel
+from .mapmarkerlist import MapMarkerList as MarkerList
+from .mapstatusbox import MapStatusBox as StatusBox
 from .mapwidget import MapWidget as Widget
+from .mapwindow import MapWindow as Window
+from .mapzoomcontrols import MapZoomControls as ZoomControls

--- a/d_rats/map/mapbottompanel.py
+++ b/d_rats/map/mapbottompanel.py
@@ -1,0 +1,88 @@
+'''Map Bottom Panel Module.'''
+#
+# Copyright 2021 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+
+from .. import map as Map
+
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+class MapMakeTrack(Gtk.CheckButton):
+    '''
+    Enable making a track on map
+
+    :param map_window: Parent Map window
+    :type map_window: :class:`Map.Window`
+    '''
+    def __init__(self, map_window):
+        Gtk.CheckButton.__init__(self)
+        self.set_label(_("Track center"))
+
+        def toggle(check_button, map_window):
+            map_window.tracking_enabled = check_button.get_active()
+
+        self.connect("toggled", toggle, map_window)
+        self.show()
+
+
+class MapControls(Gtk.Box):
+    '''
+    Make Controls for Map
+
+    :param map_window: Parent Map window
+    :type map_window: :class:`Map.Window`
+    '''
+    def __init__(self, map_window):
+        Gtk.Box.__init__(self, Gtk.Orientation.VERTICAL, 2)
+
+        zoom_control = Map.ZoomControls(map_window.map_widget)
+        self.pack_start(zoom_control, False, False, False)
+        make_track = MapMakeTrack(map_window)
+        self.pack_start(make_track, False, False, False)
+
+        self.show()
+
+
+class MapBottomPanel(Gtk.Box):
+    '''
+    Map Bottom Panel.
+
+    :param map_window: Parent Map window
+    :type map_window: :class:`Map.Window`
+    '''
+    def __init__(self, map_window):
+        Gtk.Box.__init__(self, Gtk.Orientation.HORIZONTAL, 2)
+        marker_list = Map.MarkerList(map_window)
+        self.pack_start(marker_list, True, True, True)
+        controls = MapControls(map_window)
+        self.pack_start(controls, False, False, False)

--- a/d_rats/map/mapmarkerlist.py
+++ b/d_rats/map/mapmarkerlist.py
@@ -1,0 +1,142 @@
+'''Map Marker List Module.'''
+#
+# Copyright 2021 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# import logging
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from gi.repository import GObject
+
+from .. import miscwidgets
+
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+class MapMarkerList(Gtk.ScrolledWindow):
+    '''
+    Make Marker List.
+
+    :param map_window: Parent Map window
+    :type map_window: :class:`Map.Window`
+    '''
+    cols = [(GObject.TYPE_BOOLEAN, _("Show")),
+            (GObject.TYPE_STRING, _("Station")),
+            (GObject.TYPE_FLOAT, _("Latitude")),
+            (GObject.TYPE_FLOAT, _("Longitude")),
+            (GObject.TYPE_FLOAT, _("Distance")),
+            (GObject.TYPE_FLOAT, _("Direction")),
+            ]
+
+    def __init__(self, map_window):
+        Gtk.ScrolledWindow.__init__(self)
+        self.map_window = map_window
+        self.marker_list = miscwidgets.TreeWidget(self.cols, 1, parent=False)
+        self.marker_list.toggle_cb.append(self.map_window.toggle_show)
+        # self.marker_list.connect("click-on-list", self.make_marker_popup)
+
+        # pylint: disable=protected-access
+        self.marker_list._view.connect("row-activated", self.recenter_cb)
+
+        def render_station(_col, rend, model, iter_value, _data):
+            parent = model.iter_parent(iter_value)
+            if not parent:
+                parent = iter_value
+                group = model.get_value(parent, 1)
+            if group in self.map_window.colors:
+                rend.set_property("foreground", self.map_window.colors[group])
+
+        column = self.marker_list._view.get_column(1)
+        column.set_expand(True)
+        column.set_min_width(150)
+        # r = c.get_cell_renderers()[0]
+        renderer_text = Gtk.CellRendererText()
+        column.set_cell_data_func(renderer_text, render_station)
+
+        def render_coord(_col, rend, model, iter_value, cnum):
+            if isinstance(rend, gi.repository.Gtk.Separator):
+                return
+            if model.iter_parent(iter_value):
+                rend.set_property('text', "%.4f" %
+                                  model.get_value(iter_value, cnum))
+            else:
+                rend.set_property('text', '')
+
+        for col in [2, 3]:
+            column = self.marker_list._view.get_column(col)
+            # renderer_text = column.get_cell_renderers()[0]
+            renderer_text = Gtk.CellRendererText()
+            column.set_cell_data_func(renderer_text, render_coord, col)
+
+        def render_dist(_col, rend, model, iter_value, cnum):
+            if model.iter_parent(iter_value):
+                rend.set_property('text', "%.2f" %
+                                  model.get_value(iter_value, cnum))
+            else:
+                rend.set_property('text', '')
+
+        for col in [4, 5]:
+            column = self.marker_list._view.get_column(col)
+            # renderer_text = column.get_cell_renderers()[0]
+            renderer_text = Gtk.CellRendererText()
+            column.set_cell_data_func(renderer_text, render_dist, col)
+
+        self.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.add(self.marker_list.packable())
+        self.set_size_request(-1, 150)
+        self.show()
+
+
+    def recenter_cb(self, view, path, column, data=None):
+        '''
+        Recenter Callback.
+
+        :param view: Gtk.TreeView object that received signal
+        :param path: Gtk.TreePath for the activated row
+        :param column: Gtk.TreeviewColumn that was activated
+        :param data: Optional data, Default None
+        '''
+        print("recenter_cb")
+        print("self", type(self))
+        print("path", type(self))
+        print("column", type(column))
+        print("data", type(data))
+        model = view.get_model()
+        if model.iter_parent(model.get_iter(path)) is None:
+            return
+
+        items = self.marker_list.get_selected()
+
+        self.map_window.center_mark = items[1]
+        self.map_window.recenter(items[2], items[3])
+
+        self.map_window.sb_center.pop(self.map_window.STATUS_CENTER)
+        self.map_window.sb_center.push(self.map_window.STATUS_CENTER,
+                                       _("Center") + ": %s" %
+                                       self.map_window.center_mark)

--- a/d_rats/map/mapstatusbox.py
+++ b/d_rats/map/mapstatusbox.py
@@ -1,0 +1,69 @@
+'''Map Status Box Module.'''
+#
+# Copyright 2021 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# import logging
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+class MapStatusBox(Gtk.Box):
+    '''
+    Map Status Box.
+
+    Create a status box for Map information
+    '''
+
+    def __init__(self):
+        Gtk.Box.__init__(self, Gtk.Orientation.HORIZONTAL, 2)
+
+        self.sb_coords = Gtk.Statusbar()
+        self.sb_coords.show()
+        # self.sb_coords.set_has_resize_grip(False)
+
+        self.sb_center = Gtk.Statusbar()
+        self.sb_center.show()
+        # self.sb_center.set_has_resize_grip(False)
+
+        self.sb_gps = Gtk.Statusbar()
+        self.sb_gps.show()
+
+        self.sb_prog = Gtk.ProgressBar()
+        self.sb_prog.set_size_request(150, -1)
+        self.sb_prog.show()
+
+        self.pack_start(self.sb_coords, True, True, True)
+        self.pack_start(self.sb_center, True, True, True)
+        self.pack_start(self.sb_prog, False, False, False)
+        self.pack_start(self.sb_gps, True, True, True)
+        self.show()

--- a/d_rats/map/mapwidget.py
+++ b/d_rats/map/mapwidget.py
@@ -28,7 +28,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-# Silence pylint warnings
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
 if not '_' in locals():
     import gettext
     _ = gettext.gettext
@@ -96,3 +97,19 @@ class MapWidget(Gtk.DrawingArea):
         #self.set_size_request(self.tilesize * self.width,
         #                      self.tilesize * self.height)
         #self.connect("draw", self.expose)
+
+    def set_zoom(self, zoom):
+        '''
+        Set Zoom Level.
+
+        If the Zoom level changes, this should cause a Map redraw.
+        :param zoom: Zoom level to set
+        :type zoom: int
+        '''
+        # What should happen for zoom in [0, 1, 2]?
+        if zoom > 18 or zoom == 3:
+            return
+
+        self.zoom = zoom
+        self.map_tiles = []
+        # self.queue_draw()

--- a/d_rats/map/mapzoomcontrols.py
+++ b/d_rats/map/mapzoomcontrols.py
@@ -1,0 +1,96 @@
+'''Map Zoom Controls Module.'''
+#
+# Copyright 2021 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# import logging
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+class MapZoomControls(Gtk.Frame):
+    '''
+    Map zoom controls.
+
+    :param map_widget: Map Widget for control
+    :type map_widget: :class:`Map.Widget`
+    :param zoom: Initial zoom level, Default 14
+    :type zoom: int
+    '''
+    def __init__(self, map_widget, zoom=14):
+        Gtk.Frame.__init__(self)
+        zoom_label = _("Zoom") + " (%i)" % zoom
+        self.set_label(zoom_label)
+        self.map_widget = map_widget
+        self.set_label_align(0.5, 0.5)
+        self.set_size_request(150, 50)
+        self.show()
+
+        box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 3)
+        box.set_border_width(3)
+        box.show()
+
+        label = Gtk.Label.new(_("Min"))
+        label.show()
+        box.pack_start(label, 0, 0, 0)
+
+        # mm here the allowed zoom levels are from 2 to 17 (increased to 18)
+        adj = Gtk.Adjustment.new(value=zoom,
+                                 lower=2,
+                                 upper=18,
+                                 step_increment=1,
+                                 page_increment=3,
+                                 page_size=0)
+        # scroll_bar = Gtk.HScrollbar(adj)
+        scroll_bar = Gtk.Scrollbar.new(Gtk.Orientation.HORIZONTAL, adj)
+        scroll_bar.show()
+        box.pack_start(scroll_bar, 1, 1, 1)
+
+        label = Gtk.Label.new(_("Max"))
+        label.show()
+        box.pack_start(label, 0, 0, 0)
+
+        self.add(box)
+
+        scroll_bar.connect("value-changed", self.zoom, self)
+
+
+    def zoom(self, adj, frame):
+        '''
+        Zoom.
+
+        :param adj: Gtk.Adjustment object
+        :param frame: Frame for zoom
+        '''
+        print("self:", type(self))
+        print("adj)", type(adj))
+        print("frame", type(frame))
+        self.map_widget.set_zoom(int(adj.get_value()))
+        self.set_label(_("Zoom") + " (%i)" % int(adj.get_value()))


### PR DESCRIPTION
d_rats/map/__init__.py:
  Add MapBottomPanel, MapMarkerList, MapStatusBox, and MapZoomControls.

d_rats/map/mapbottompanel.py:
  Classes for the Map Bottom Panel.

d_rats/map/mapmarkerlist.py:
  Class for Map Marker List.

d_rats/map/mapstatusbox.py:
  Class for Map Status Box.

d_rats/map/mapwidget.py;
  Minor fixes.

d_rats/map/mapwindow.py:
  Remove code for constructing MapBottomPanel, MapMarkerList,
  MapStatusBox, and MapZoomControls

d_rats/map/mapzoomcontrols.py:
  Class for Map Zoom Controls