### PR TITLE
Adding the Map Menu

### DIFF
--- a/d_rats/map/__init__.py
+++ b/d_rats/map/__init__.py
@@ -2,6 +2,7 @@
 
 from .mapbottompanel import MapBottomPanel as BottomPanel
 from .mapmarkerlist import MapMarkerList as MarkerList
+from .mapmenumodel import MapMenuModel as MenuModel
 from .mapstatusbox import MapStatusBox as StatusBox
 from .mapwidget import MapWidget as Widget
 from .mapwindow import MapWindow as Window

--- a/d_rats/map/mapbottompanel.py
+++ b/d_rats/map/mapbottompanel.py
@@ -42,7 +42,7 @@ class MapMakeTrack(Gtk.CheckButton):
     Enable making a track on map
 
     :param map_window: Parent Map window
-    :type map_window: :class:`Map.Window`
+    :type map_window: :class:`map.MapWindow`
     '''
     def __init__(self, map_window):
         Gtk.CheckButton.__init__(self)
@@ -60,7 +60,7 @@ class MapControls(Gtk.Box):
     Make Controls for Map
 
     :param map_window: Parent Map window
-    :type map_window: :class:`Map.Window`
+    :type map_window: :class:`map.MapWindow`
     '''
     def __init__(self, map_window):
         Gtk.Box.__init__(self, Gtk.Orientation.VERTICAL, 2)
@@ -78,7 +78,7 @@ class MapBottomPanel(Gtk.Box):
     Map Bottom Panel.
 
     :param map_window: Parent Map window
-    :type map_window: :class:`Map.Window`
+    :type map_window: :class:`map.MapWindow`
     '''
     def __init__(self, map_window):
         Gtk.Box.__init__(self, Gtk.Orientation.HORIZONTAL, 2)

--- a/d_rats/map/mapmarkerlist.py
+++ b/d_rats/map/mapmarkerlist.py
@@ -44,7 +44,7 @@ class MapMarkerList(Gtk.ScrolledWindow):
     Make Marker List.
 
     :param map_window: Parent Map window
-    :type map_window: :class:`Map.Window`
+    :type map_window: :class:`map.MapWindow`
     '''
     cols = [(GObject.TYPE_BOOLEAN, _("Show")),
             (GObject.TYPE_STRING, _("Station")),

--- a/d_rats/map/mapmenumodel.py
+++ b/d_rats/map/mapmenumodel.py
@@ -1,0 +1,110 @@
+'''Map Window Menu Model Module.'''
+#
+# Copyright 2021 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# import logging
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gio
+
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+# pylint wants at least 2 public methods.
+# pylint: disable=too-few-public-methods
+class MapMenuModel(Gio.Menu):
+    '''Creates the Menu Model for MapWindow.'''
+
+    def __init__(self):
+        Gio.Menu.__init__(self)
+
+        item_refresh = Gio.MenuItem.new(_("Refresh"), 'win.refresh')
+        item_clearcache = Gio.MenuItem.new(_("Delete local Map cache"),
+                                           'win.clearcache')
+        item_editsources = Gio.MenuItem.new(_("Edit Sources"),
+                                            'win.editsources')
+
+        menu_map = Gio.Menu.new()
+        menu_map.append_item(item_refresh)
+        menu_map.append_item(item_clearcache)
+        menu_map.append_item(item_editsources)
+
+        item_printable = Gio.MenuItem.new(_('Printable'), 'win.printable')
+        item_printablevis = Gio.MenuItem.new(_("Printable (visible area)"),
+                                             'win.printablevis')
+        item_save = Gio.MenuItem.new(_("Save Image"), 'win.save')
+        item_savevis = Gio.MenuItem.new(_('Save Image (visible area)'),
+                                        'win.savevis')
+        menu_export = Gio.Menu.new()
+        menu_export.append_item(item_printable)
+        menu_export.append_item(item_printablevis)
+        menu_export.append_item(item_save)
+        menu_export.append_item(item_savevis)
+
+        menu_map.append_submenu(_("Export"), menu_export)
+        self.append_submenu(_("Map"), menu_map)
+
+    @staticmethod
+    def add_actions(window):
+        '''
+        Add menu actions to the window.
+
+        :param window: The map window
+        :type window: 'map.Mapwindow
+        '''
+
+        action_refresh = Gio.SimpleAction.new('refresh', None)
+        action_refresh.connect('activate', window.refresh_item_handler)
+        window.add_action(action_refresh)
+
+        action_clearcache = Gio.SimpleAction.new('clearcache', None)
+        action_clearcache.connect('activate', window.clearcache_item_handler)
+        window.add_action(action_clearcache)
+
+        action_editsources = Gio.SimpleAction.new('editsources', None)
+        action_editsources.connect('activate', window.editsources_item_handler)
+        window.add_action(action_editsources)
+
+        action_printable = Gio.SimpleAction.new('printable', None)
+        action_printable.connect('activate', window.printable_item_handler)
+        window.add_action(action_printable)
+
+        action_printablevis = Gio.SimpleAction.new('printablevis', None)
+        action_printablevis.connect('activate',
+                                    window.printablevis_item_handler)
+        window.add_action(action_printablevis)
+
+        action_save = Gio.SimpleAction.new('save', None)
+        action_save.connect('activate', window.save_item_handler)
+        window.add_action(action_save)
+
+        action_savevis = Gio.SimpleAction.new('savevis', None)
+        action_savevis.connect('activate', window.savevis_item_handler)
+        window.add_action(action_savevis)

--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -34,19 +34,11 @@ from gi.repository import GLib
 
 from .. import map as Map
 
-
 # This makes pylance happy with out overriding settings
 # from the invoker of the class
 if not '_' in locals():
     import gettext
     _ = gettext.gettext
-
-
-class MapMenuBar(Gtk.MenuBar):
-    '''Menu for map.'''
-
-    def __init__(self):
-        Gtk.MenuBar.__init__(self)
 
 
 # We have more than 7 instance attributes
@@ -106,7 +98,7 @@ class MapWindow(Gtk.ApplicationWindow):
 
         box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 2)
 
-        self.menubar = MapMenuBar()
+        self.menubar = self._make_menu()
         self.menubar.show()
 
         box.pack_start(self.menubar, False, False, False)
@@ -116,8 +108,8 @@ class MapWindow(Gtk.ApplicationWindow):
         self.scrollw.show()
 
         self.map_widget.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
-        self.map_widget.connect("motion-notify-event", self.mouse_move_event)
-        self.scrollw.connect("button-press-event", self.mouse_click_event)
+        self.map_widget.connect("motion-notify-event", self._mouse_move_event)
+        self.scrollw.connect("button-press-event", self._mouse_click_event)
 
         self.statusbox = Map.StatusBox()
         box.pack_start(self.scrollw, True, True, True)
@@ -132,7 +124,131 @@ class MapWindow(Gtk.ApplicationWindow):
         self.add(box)
 
 
-    def mouse_click_event(self, widget, event):
+    def add_map_source(self, maps):
+        '''
+        Add Map Source.
+
+        :param maps: Maps
+        :type maps: list
+        '''
+        print("add_map_source %s" % maps, type(maps), type(self))
+
+    # Inherited from Parent and called by mainapp
+    # def connect(self, signal name, function):
+
+    # called my mainapp
+    def get_map_source(self, station):
+        '''
+        Get Map source.
+
+        :param station: Station information
+        :type station: str?
+        :returns: maps for a station
+        :rtype: list?
+        '''
+        print("get_map_source %s" % station, type(station), type(self))
+
+    # Called by mainapp and qst.py
+    def get_map_sources(self):
+        '''
+        Get Map Sources.
+
+        :returns: Map sources
+        :rtype: list
+        '''
+        print("get_map_sources", type(self))
+        return []
+
+    def refresh_item_handler(self, action, _value):
+        '''
+        Refresh Item Handler.
+
+        :param action: Action that was invoked
+        :type action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused.
+        '''
+        print("refresh_item_handler", type(self))
+        print('Action: %s\n value: %s' % (action, _value))
+
+    def clearcache_item_handler(self, action, _value):
+        '''
+        Clear Cache Handler.
+
+        :param action: Action that was invoked
+        :type action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused.
+        '''
+        print("Clear Cache handler", type(self))
+        print('Action: %s\n value: %s' % (action, _value))
+
+    def editsources_item_handler(self, action, _value):
+        '''
+        Edit Sources Handler.
+
+        :param action: Action that was invoked
+        :type action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused.
+        '''
+        print("Edit Sources handler", type(self))
+        print('Action: %s\n value: %s' % (action, _value))
+
+    def printable_item_handler(self, action, _value):
+        '''
+        Printable Item Handler.
+
+        :param action: Action that was invoked
+        :type action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused.
+        '''
+        print("Printable Item handler", type(self))
+        print('Action: %s\n value: %s' % (action, _value))
+
+    def printablevis_item_handler(self, action, _value):
+        '''
+        Printable Visible Item Handler.
+
+        :param action: Action that was invoked
+        :type action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused.
+        '''
+        print("Printable Visible Item handler", type(self))
+        print('Action: %s\n value: %s' % (action, _value))
+
+    def save_item_handler(self, action, _value):
+        '''
+        Save Item Handler.
+
+        :param action: Action that was invoked
+        :type action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused.
+        '''
+        print("Save Item handler", type(self))
+        print('Action: %s\n value: %s' % (action, _value))
+
+    def savevis_item_handler(self, action, _value):
+        '''
+        Save Visible Item Handler.
+
+        :param action: Action that was invoked
+        :type action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused.
+        '''
+        print("Save Visible Item handler", type(self))
+        print('Action: %s\n value: %s' % (action, _value))
+
+    def _make_menu(self):
+        '''
+        Menu for map.
+
+        :returns: Menu for map
+        :rtype: :class:`Gtk.Menubar`
+        '''
+        model = Map.MenuModel()
+        model.add_actions(self)
+        menubar = Gtk.MenuBar.new_from_model(model)
+        return menubar
+
+    def _mouse_click_event(self, widget, event):
         '''
         Mouse Click Event.
 
@@ -180,12 +296,12 @@ class MapWindow(Gtk.ApplicationWindow):
 
         #    self.recenter(lat, lon)
 
-    def mouse_move_event(self, _widget, event):
+    def _mouse_move_event(self, _widget, event):
         '''
         Mouse Move Event.
 
         :param _widget: Widget that received the signal, Not used
-        :type _widget: :class:`Map.Widget`
+        :type _widget: :class:`map.MapWidget`
         :param event: Event that triggered this handler.
         :type event: :class:`Gdk.EventMotion`
         :returns: True to stop other handlers from being invoked
@@ -268,6 +384,9 @@ class MapWindow(Gtk.ApplicationWindow):
 
         return False
 
+    # Called by mainapp not sure if inherited
+    # def queue_draw(self):
+
 
     def recenter(self, lat, lon):
         '''
@@ -281,6 +400,33 @@ class MapWindow(Gtk.ApplicationWindow):
         # self.refresh_marker_list()
         # self.center_on(lat, lon)
         # self.map_widget.queue_draw()
+
+    # Called my mainapp, inherited
+    # def show(self)
+
+    # called by mainapp
+    def set_center(self, latitude, longitude):
+        '''
+        Set Map Center.
+
+        :param latitude: Latitude of new center
+        :type longitude: float
+        :param Longitude: Longitude of new center
+        :type Longitude: float
+        '''
+
+    # public method used by mainap inherited from parent
+    # def set_title(self, str)
+
+    # Called by mainapp
+    def set_zoom(self, zoom):
+        '''
+        Set zoom level.
+
+        :param zoom: zoom level from 3 to 18?
+        :type zoom: int
+        '''
+        self.map_widget.set_zoom(zoom)
 
     # pylint: disable=no-self-argument
     def status(fraction, message):
@@ -332,7 +478,12 @@ class MapWindow(Gtk.ApplicationWindow):
         #    break
         # self.map_widget.queue_draw()
 
-    @staticmethod
-    def test():
-        '''Test method.'''
-        Gtk.main()
+    # Called from Mainapp
+    def update_gps_status(self, gps_status):
+        '''
+        Update GPS Status.
+
+        :param gps_status: GPS status
+        :type gps_status: str
+        '''
+        print("update_gps_status %s" % gps_status, type(self))


### PR DESCRIPTION
Add the Map menu with the functions stubbed out.

d_rats/map/__init__.py:
   New MapMenuModel class.

d_rats/map/mapbottompanel.py:
d_rats/map/markerlist.py:
   Minor documentation fixes.

d_rats/map/mapmenumodule.py:
   Class for creating the Map menu and associated actions.

d_rats/map/mapwindow.py:
   Move the Map Menu into its own class and add the handlers.
   Add stub routines for the current public methods for mapwindow.