### PR TITLE
Connect lat,lon, and zoom to map

### DIFF
--- a/d_rats/map/__init__.py
+++ b/d_rats/map/__init__.py
@@ -6,6 +6,7 @@ from .mapmarkerlist import MapMarkerList as MarkerList
 from .mapmenumodel import MapMenuModel as MenuModel
 from .mapposition import MapPosition as Position
 from .mapstatusbox import MapStatusBox as StatusBox
+from .maptile import MapTile as Tile
 from .mapwidget import MapWidget as Widget
 from .mapwindow import MapWindow as Window
 from .mapzoomcontrols import MapZoomControls as ZoomControls

--- a/d_rats/map/mapdisplay.py
+++ b/d_rats/map/mapdisplay.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
+import os
 import gi
 
 gi.require_version('Gtk', '3.0')
@@ -63,6 +64,19 @@ class MapDisplay(Gtk.Application):
         self.cmd_args = cmd_args
         get_platform(cmd_args.config)
 
+        mapurl = self.config.get("settings", "mapurlbase")
+
+        Map.Tile.set_connected(True)
+
+        lifetime = self.config.getint("settings", "map_tile_ttl") * 3000
+        Map.Tile.set_tile_lifetime(lifetime)
+        mapdir = self.config.get("settings", "mapdir")
+        maptype = self.config.get("settings", "maptype")
+        map_path = os.path.join(mapdir, maptype)
+
+        Map.Tile.set_map_info(map_path, mapurl)
+        Map.Tile.set_proxy = self.config.get("settings", "http_proxy") or None
+        self.map_window = None
 
     # pylint: disable=arguments-differ
     def do_activate(self):
@@ -72,6 +86,7 @@ class MapDisplay(Gtk.Application):
         Emits a :class:`Gio.Application` signal to the application.
         '''
         map_window = Map.Window(self, self.config)
+        self.map_window = map_window  # Temporary
         map_window.set_title("D-RATS Test Map Window - map in use: %s" %
                              self.config.get("settings", "maptype"))
 
@@ -80,6 +95,51 @@ class MapDisplay(Gtk.Application):
         map_window.set_zoom(14)
 
         map_window.show()
+
+    # Currently referenced by mainapp, will be moved to Mapwindow calls
+    def set_base_dir(self, basedir, mapurl, mapkey):
+        '''
+        Set Base Directory.
+
+        :param basedir: Base directory
+        :type basedir: str
+        :param mapurl: URL of Map
+        :type mapurl: str
+        :param mapkey: Map access key
+        :type mapkey: str
+        '''
+        self.map_window.set_base_dir(basedir, mapurl, mapkey)
+
+    # Currently referenced by mainapp, will be moved to Mapwindow calls
+    def set_connected(self, connected):
+        '''
+        Set Connected.
+
+        :param connected: New connected state
+        :type connected: bool
+        '''
+        self.map_window.set_connected(connected)
+
+    # Currently referenced by mainapp, will be moved to Mapwindow calls
+    def set_proxy(self, proxy):
+        '''
+        Set Proxy.
+
+        :param proxy: Proxy to use
+        :type proxy: str
+        '''
+        self.map_window.set_proxy(proxy)
+
+    # Currently referenced by mainapp, will be moved to Mapwindow calls
+    def set_tile_lifetime(self, lifetime):
+        '''
+        Set tile Lifetime.
+
+        :param lifetime: Cache lifetime in seconds
+        :param lifetime: int
+        '''
+        self.map_window.set_tile_lifetime(lifetime)
+
 
 
 def main():
@@ -153,19 +213,6 @@ def main():
         format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
         datefmt="%m/%d/%Y %H:%M:%S",
         level=args.loglevel)
-
-    # mapurl = conf.get("settings", "mapurlbase")
-    # mapkey = ""
-
-    # set_connected(True)
-    # set_tile_lifetime(conf.getint("settings", "map_tile_ttl") * 3600)
-
-
-    # set_base_dir(os.path.join(conf.get("settings", "mapdir"),
-    #                          conf.get("settings", "maptype")), mapurl, mapkey)
-    # proxy = conf.get("settings", "http_proxy") or None
-    # set_proxy(proxy)
-
 
     # WB8TYW: DratsConfig takes an unused argument.
 

--- a/d_rats/map/mapdraw.py
+++ b/d_rats/map/mapdraw.py
@@ -23,8 +23,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import gi
-gi.require_version("Gdk", "3.0")
-from gi.repository import Gdk
+# gi.require_version("Gdk", "3.0")
+# from gi.repository import Gdk
 gi.require_version("PangoCairo", "1.0")
 from gi.repository import PangoCairo
 
@@ -92,6 +92,7 @@ class MapDraw():
         cls.map_visible['y_start'] = int(scrollw.get_vadjustment().get_value())
         cls.map_visible['y_size'] = int(
             scrollw.get_vadjustment().get_page_size())
+        map_widget.calculate_bounds()
 
         cls.scale(cls)
             # map_widget.expose_map(cairo_ctx)
@@ -123,7 +124,7 @@ class MapDraw():
             pass
 
     # pylint: disable=too-many-locals
-    def scale(self, pixels=128):
+    def scale(self):
         '''
         Draw the scale ladder on the Map.
 
@@ -134,13 +135,11 @@ class MapDraw():
         '''
         # Need to find out about magic number 128 for pixels.
 
-        dist = self.map_widget.map_distance_with_units(pixels)
-
-        pango_layout = self.map_widget.create_pango_layout(dist)
+        pango_layout = self.map_widget.map_scale_pango_layout()
         pango_width, pango_height = pango_layout.get_pixel_size()
 
-        color = Gdk.RGBA()
-        color.parse('black')
+        color = self.map_widget.color_black
+        pixels = self.map_widget.pixels
         self.cairo_ctx.save()
 
         self.cairo_ctx.set_source_rgba(color.red,

--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -408,7 +408,6 @@ class MapWindow(Gtk.ApplicationWindow):
     # Called by mainapp not sure if inherited
     # def queue_draw(self):
 
-
     def recenter(self, position):
         '''
         Recenter Map to position.
@@ -440,6 +439,57 @@ class MapWindow(Gtk.ApplicationWindow):
         position = Map.Position(latitude, longitude)
         self.map_widget.set_center(position)
 
+    # Called by mainapp
+    def set_base_dir(self, base_dir, map_url, map_key):
+        '''
+        Set Base Directory.
+
+        :param base_dir: Base directory
+        :type base_dir: str
+        :param map_url: URL of Map
+        :type map_url: str
+        :param map_key: Map access key
+        :type map_key: str
+        '''
+        Map.Tile.set_base_dir(base_dir)
+        Map.Tile.set_map_url_and_key(map_url, map_key)
+        self.logger.info("BASE_DIR configured to %s", base_dir)
+        self.logger.info("MAP_URL configured to: %s", map_url)
+        self.logger.debug("MAP_URL_KEY configured to: %s", map_key)
+
+    # Called by mainap
+    @staticmethod
+    def set_connected(connected):
+        '''
+        Set Connected.
+
+        :param connected: New connected state
+        :type connected: bool
+        '''
+        Map.Tile.set_connected(connected)
+
+    # Called by mainapp
+    @staticmethod
+    def set_proxy(proxy):
+        '''
+        Set Proxy.
+
+        :param proxy: Proxy to use
+        :type proxy: str
+        '''
+        Map.Tile.set_proxy(proxy)
+
+    # Called by mainap
+    @staticmethod
+    def set_tile_lifetime(lifetime):
+        '''
+        Set tile Lifetime.
+
+        :param lifetime: Cache lifetime in seconds
+        :param lifetime: int
+        '''
+        Map.Tile.set_tile_lifetime(lifetime)
+
     # public method used by mainap inherited from parent
     # def set_title(self, str)
 
@@ -448,7 +498,7 @@ class MapWindow(Gtk.ApplicationWindow):
         '''
         Set zoom level.
 
-        :param zoom: zoom level from 3 to 18?
+        :param zoom: zoom level from 2 to 18
         :type zoom: int
         '''
         self.mapcontrols.zoom_control.level = zoom

--- a/d_rats/map/mapzoomcontrols.py
+++ b/d_rats/map/mapzoomcontrols.py
@@ -30,6 +30,8 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from gi.repository import GLib
 
+from .. import map as Map
+
 # This makes pylance happy with out overriding settings
 # from the invoker of the class
 if not '_' in locals():
@@ -55,6 +57,7 @@ class MapZoomControls(Gtk.Frame):
     def __init__(self, map_widget, zoom=None):
         Gtk.Frame.__init__(self)
         self.__level = self.sanitize_level(zoom)
+        Map.Tile.set_zoom(self.__level)
         zoom_label = _("Zoom") + " (%i)" % self.__level
         self.set_label(zoom_label)
         self.map_widget = map_widget
@@ -164,6 +167,7 @@ class MapZoomControls(Gtk.Frame):
             return True
         self.__last_zoom = None
         self.__level = zoom_value
+        Map.Tile.set_zoom(zoom_value)
         # This should signal a map redraw event
         self.map_widget.queue_draw()
         return False


### PR DESCRIPTION
d_rats/map/__init__.py:
  Add MapDraw class.

d_rats/map/mapdisplay.py:
  Temporarily add methods called by mainapp.

d_rats/map/mapdraw.py:
  Move creating the pango layout info MapWidget.
  Move creating the constant Gdk color black into mapwidget.

d_rats/map/mapwidget.pylint
  Refactor to create map_scale_pango_layout as a simplification
  Add calculate_bounds method

d_rats/map/mapwindow.py:
  Add methods to be called by mainapp replacing calls to mapdisplay.

d_rats/map/mapzoomcontrols.py:
  Copy zoom setting into MapTile class