### PR TITLE
Make map downloading operational

### DIFF
--- a/d_rats/map/__init__.py
+++ b/d_rats/map/__init__.py
@@ -6,6 +6,7 @@ from .mapmarkerlist import MapMarkerList as MarkerList
 from .mapmenumodel import MapMenuModel as MenuModel
 from .mapposition import MapPosition as Position
 from .mapstatusbox import MapStatusBox as StatusBox
+from .mapexception import MapException
 from .maptile import MapTile as Tile
 from .mapwidget import MapWidget as Widget
 from .mapwindow import MapWindow as Window

--- a/d_rats/map/mapexception.py
+++ b/d_rats/map/mapexception.py
@@ -1,0 +1,17 @@
+# Copyright 2021 John Malmberg <wb8tyw@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+class MapException(Exception):
+    '''Generic Map Exception.'''

--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -103,6 +103,7 @@ class MapWindow(Gtk.ApplicationWindow):
         self.map_widget = Map.Widget(width=tiles, height=tiles,
                                      window=self)
         self.map_widget.show()
+        Map.Tile.set_map_widget(self.map_widget)
 
         self.scrollw = Gtk.ScrolledWindow()
         self.scrollw.add(self.map_widget)
@@ -173,25 +174,15 @@ class MapWindow(Gtk.ApplicationWindow):
         print("get_map_sources", type(self))
         return []
 
-    def refresh_item_handler(self, action, _value):
+    def refresh_item_handler(self, _action, _value):
         '''
         Refresh Item Handler.
 
-        :param action: Action that was invoked
-        :type action: :class:`GioSimpleAction`
-        :param _value: Value for action, Unused.
+        :param _action: Action that was invoked, Unused
+        :type _action: :class:`GioSimpleAction`
+        :param _value: Value for action, Unused
         '''
-        print("refresh_item_handler", type(self))
-        print('Action: %s\n value: %s' % (action, _value))
-        self.statusbox.sb_center.pop(self.STATUS_CENTER)
-        self.statusbox.sb_center.push(self.STATUS_CENTER,
-                                      _("Center") + ": %s" % "refresh")
-        self.update_gps_status("GPS test string")
-        if self.__temp_frac < 1.0:
-            self.__temp_frac += 0.1
-        self.statusbox.sb_prog.set_text(_("Loaded") + " %.0f%%" %
-                                        (self.__temp_frac * 100.0))
-        self.statusbox.sb_prog.set_fraction(self.__temp_frac)
+        self.map_widget.queue_draw()
 
     def clearcache_item_handler(self, action, _value):
         '''


### PR DESCRIPTION
d_rats/map/__init__.py:
  Add MapException class.

d_rats/map/mapdraw.py:
  Minor fix to LoadContext/fraction property.
  Remove commented out code that will not be used.
  Fix progress to report % of tiles that were successfully downloaded.
  Fix exception handling for cairo errors.
  Enable threaded Tile Fetch.

d_rats/map/mapexception.py:
  Base Map Exception class.

d_rats/map/maptile.py:
  Add class methods to store formerly global values.
  Add fetch_url method and enable fetching.

d_rats/map/mapwindow.py:
  Store map_widget reference in MapTile class.
  Remove test code from refresh_item_handler.

d_rats/map/mapzoomcontrols.py:
  Improved fix for over sensitive zoom slider control
  Store zoom level in MapTile class