### PR TITLE
Enable Map print and save options

### DIFF
--- a/d_rats/map/mapdraw.py
+++ b/d_rats/map/mapdraw.py
@@ -81,6 +81,7 @@ class MapDraw():
     '''
 
     __broken_tile = None
+    __center = None
 
     def __init__(self, map_widget, cairo_ctx):
         self.map_widget = map_widget
@@ -90,6 +91,18 @@ class MapDraw():
         self.sb_prog = None
         self.map_visible = None
         self.logger = logging.getLogger("MapDraw")
+
+    @classmethod
+    def set_center(cls, pos):
+        '''
+        Set Center.
+
+        Set a flag to have the window scrollbars centered.
+
+        :param pos: New center position
+        :type pos: :class:`Map.MapPosition
+        '''
+        cls.__center = pos
 
     @classmethod
     def handler(cls, map_widget, cairo_ctx):
@@ -125,14 +138,25 @@ class MapDraw():
         # For larger sliders the scale will move a bit depending on how the
         # window position was updated.
         self.map_visible['slider_size'] = max(slider_size, 20)
-        self.map_visible['x_start'] = int(
-            scrollw.get_hadjustment().get_value())
-        self.map_visible['x_size'] = int(
-            scrollw.get_hadjustment().get_page_size())
-        self.map_visible['y_start'] = int(scrollw.get_vadjustment().get_value())
-        self.map_visible['y_size'] = int(
-            scrollw.get_vadjustment().get_page_size())
+        hadj = scrollw.get_hadjustment()
+        self.map_visible['x_start'] = int(hadj.get_value())
+        h_page_size = hadj.get_page_size()
+        self.map_visible['x_size'] = int(h_page_size)
+        vadj = scrollw.get_vadjustment()
+        self.map_visible['y_start'] = int(vadj.get_value())
+        v_page_size = vadj.get_page_size()
+        self.map_visible['y_size'] = int(v_page_size)
         map_widget.calculate_bounds()
+
+        if cls.__center:
+            # We do not know the page size of the scrollbars until we get
+            # here, so self._center is used to let us know when we need to
+            # have the program adjust the scrollbars to the new center.
+            x_axis, y_axis = map_widget.latlon2xy(cls.__center)
+
+            hadj.set_value(x_axis - (h_page_size / 2))
+            vadj.set_value(y_axis - (v_page_size / 2))
+            cls.__center = None
 
         self.expose_map()
         self.scale()

--- a/d_rats/map/mapmenumodel.py
+++ b/d_rats/map/mapmenumodel.py
@@ -56,16 +56,18 @@ class MapMenuModel(Gio.Menu):
         menu_map.append_item(item_clearcache)
         menu_map.append_item(item_editsources)
 
-        item_printable = Gio.MenuItem.new(_('Printable'), 'win.printable')
+        # It looks like we can only print the visible area, so disable
+        # the non-functional menu items.
+        # item_printable = Gio.MenuItem.new(_('Printable'), 'win.printable')
         item_printablevis = Gio.MenuItem.new(_("Printable (visible area)"),
                                              'win.printablevis')
-        item_save = Gio.MenuItem.new(_("Save Image"), 'win.save')
+        # item_save = Gio.MenuItem.new(_("Save Image"), 'win.save')
         item_savevis = Gio.MenuItem.new(_('Save Image (visible area)'),
                                         'win.savevis')
         menu_export = Gio.Menu.new()
-        menu_export.append_item(item_printable)
+        # menu_export.append_item(item_printable)
         menu_export.append_item(item_printablevis)
-        menu_export.append_item(item_save)
+        # menu_export.append_item(item_save)
         menu_export.append_item(item_savevis)
 
         menu_map.append_submenu(_("Export"), menu_export)
@@ -81,30 +83,30 @@ class MapMenuModel(Gio.Menu):
         '''
 
         action_refresh = Gio.SimpleAction.new('refresh', None)
-        action_refresh.connect('activate', window.refresh_item_handler)
+        action_refresh.connect('activate', window.item_refresh_handler)
         window.add_action(action_refresh)
 
         action_clearcache = Gio.SimpleAction.new('clearcache', None)
-        action_clearcache.connect('activate', window.clearcache_item_handler)
+        action_clearcache.connect('activate', window.item_clearcache_handler)
         window.add_action(action_clearcache)
 
         action_editsources = Gio.SimpleAction.new('editsources', None)
-        action_editsources.connect('activate', window.editsources_item_handler)
+        action_editsources.connect('activate', window.item_editsources_handler)
         window.add_action(action_editsources)
 
-        action_printable = Gio.SimpleAction.new('printable', None)
-        action_printable.connect('activate', window.printable_item_handler)
-        window.add_action(action_printable)
+        # action_printable = Gio.SimpleAction.new('printable', None)
+        # action_printable.connect('activate', window.item_printable_handler)
+        # window.add_action(action_printable)
 
         action_printablevis = Gio.SimpleAction.new('printablevis', None)
         action_printablevis.connect('activate',
-                                    window.printablevis_item_handler)
+                                    window.item_printablevis_handler)
         window.add_action(action_printablevis)
 
-        action_save = Gio.SimpleAction.new('save', None)
-        action_save.connect('activate', window.save_item_handler)
-        window.add_action(action_save)
+        # action_save = Gio.SimpleAction.new('save', None)
+        # action_save.connect('activate', window.item_save_handler)
+        # window.add_action(action_save)
 
         action_savevis = Gio.SimpleAction.new('savevis', None)
-        action_savevis.connect('activate', window.savevis_item_handler)
+        action_savevis.connect('activate', window.item_savevis_handler)
         window.add_action(action_savevis)

--- a/d_rats/map/mapzoomcontrols.py
+++ b/d_rats/map/mapzoomcontrols.py
@@ -54,7 +54,8 @@ class MapZoomControls(Gtk.Frame):
     ZOOM_MAX = 18
     ZOOM_DEFAULT = 14
 
-    __level = ZOOM_DEFAULT
+    __level = 0
+    __prev_level = 0
 
     def __init__(self, map_widget, zoom=None):
         Gtk.Frame.__init__(self)
@@ -177,9 +178,12 @@ class MapZoomControls(Gtk.Frame):
         if (time.time() - time_zoom) < 0.5:
             # Waiting for slider to stop moving
             return True
+
         self.__last_zoom = None
         self.__level = zoom_value
-        Map.Tile.set_zoom(zoom_value)
-        # This should signal a map redraw event
-        self.map_widget.queue_draw()
+        if self.__prev_level != zoom_value:
+            self.__prev_level = zoom_value
+            Map.Tile.set_zoom(zoom_value)
+            # This should signal a map redraw event
+            self.map_widget.queue_draw()
         return False


### PR DESCRIPTION
Enable the print and save functions for the visible map.

d_rats/map/mapdraw.py:
  Add code to set scrollbars to the center of the screen when needed.

d_rats/map/mapmenumodel.py:
  Disable the print and save entire map entries as there does not
  seem to be a good way to implement them.

d_rats/map/mapwidget.py:
  Remove some unused code.
  Add center_on method to let MqpDraw class know to center the scroll bar.
  Add export_to method for saving the visible screen to a file.

d_rats/map/mapwidget.py:
  Rename menu handler methods to allow alphabetical grouping.
  Add get_visible_bounds() method.
  Add printable_map and save_map related methods.

d_rats/map/MapZoomControls.py:
  Improve Zoom level setting.