### PR TITLE
Add Mouse Popup Menu

### DIFF
--- a/d_rats/map/__init__.py
+++ b/d_rats/map/__init__.py
@@ -4,6 +4,7 @@ from .mapbottompanel import MapBottomPanel as BottomPanel
 from .mapdraw import MapDraw as Draw
 from .mapmarkerlist import MapMarkerList as MarkerList
 from .mapmenumodel import MapMenuModel as MenuModel
+from .mappopupmodel import MapPopupModel as PopupModel
 from .mapposition import MapPosition as Position
 from .mapstatusbox import MapStatusBox as StatusBox
 from .mapexception import MapException

--- a/d_rats/map/mappopupmodel.py
+++ b/d_rats/map/mappopupmodel.py
@@ -1,0 +1,88 @@
+'''Map Popup Menu Model Module.'''
+#
+# Copyright 2021 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+# import logging
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gio
+
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+# pylint wants at least 2 public methods.
+# pylint disable=too-few-public-methods
+class MapPopupModel(Gio.Menu):
+    '''
+    Creates the Popup Menu for Mouse Click in the MapWidget.
+
+    :param position: Map Position for menu title
+    :type position: :class:`Map.MapPosition`
+    '''
+
+    def __init__(self, position):
+        Gio.Menu.__init__(self)
+
+        menu_popup = Gio.Menu()
+        menu_popup.append(_("Center here"), 'win.center')
+        menu_popup.append(_("New marker here"), 'win.newmarker')
+        menu_popup.append(_("Broadcast this location"), 'win.broadcast')
+        self.append_section(str(position), menu_popup)
+
+    @staticmethod
+    def add_actions(window):
+        '''
+        Add menu actions to the window.
+
+        :param window: The map window
+        :type window: 'map.Mapwindow
+        '''
+
+        #action_group = Gio.SimpleActionGroup()
+        action_group = window
+        action_center = Gio.SimpleAction(name='center',
+                                         parameter_type=None,
+                                         enabled=True)
+        action_center.connect('activate', window.popup_center_handler)
+        action_group.add_action(action_center)
+        #window.add_action(action_center)
+
+        action_newmarker = Gio.SimpleAction(name='newmarker',
+                                            parameter_type=None,
+                                            enabled=True)
+        action_newmarker.connect('activate', window.popup_newmarker_handler)
+        action_group.add_action(action_newmarker)
+
+        action_broadcast = Gio.SimpleAction(name='broadcast',
+                                            parameter_type=None,
+                                            enabled=True)
+        action_broadcast.connect('activate', window.popup_broadcast_handler)
+        action_group.add_action(action_broadcast)
+        #window.scrollw.insert_action_group('popup', action_group)

--- a/d_rats/map/mapwidget.py
+++ b/d_rats/map/mapwidget.py
@@ -137,18 +137,6 @@ class MapWidget(Gtk.DrawingArea):
         self._lng_fudge = ((self.width / 2) * self.tilesize) - x_axis
         self._lat_fudge = ((self.height / 2) * self.tilesize) - y_axis
 
-    # pylint: disable=no-self-use
-    def center_on(self, position):
-        '''
-        Center On.
-
-        :param position: position for new center
-        :type position: :class:`Map.MapPosition`
-        '''
-        # The scroll adjustments have no value until being exposed
-        # So we need to tell the expose handler to center them.
-        Map.Draw.set_center(position)
-
     def export_to(self, filename, bounds):
         '''
         Export To File in PNG format.
@@ -241,7 +229,10 @@ class MapWidget(Gtk.DrawingArea):
         self.position = position
         #self.map_tiles = []
         #self.refresh_marker_list()
-        self.center_on(self.position)
+
+        # The scroll adjustments have no value until being exposed
+        # So we need to tell the expose handler to center them.
+        Map.Draw.set_center(position)
         self.queue_draw()
 
     def value_x_event(self, _widget):


### PR DESCRIPTION
Add in a stubbed out mouse popup menu.

d_rats/map/__init__.py:
  Add mappopupmodel class.

d_rats/map/mappopupmodel.py:
  Popup menu for the mouse pointer

d_rats/map/mapwidget.py:
  The scroll adjustments have no value until being
  exposed, so can only be queried in the expose handler.

d_rats/map/mapwindow.py:
  Connect existing map_source_editor for testing
  Add the popup menu for the mouse.
  Make mouse movement more sensitive.