### PR TITLE
ddt2 Python3 fixes

### DIFF
--- a/d_rats/ddt2.py
+++ b/d_rats/ddt2.py
@@ -2,6 +2,7 @@
 '''ddt2'''
 #
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
+# Copyright 2021 John. E. Malmberg - Python3 Conversion
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +20,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
 import struct
 import zlib
 # import base64
@@ -26,13 +28,12 @@ import sys
 
 import threading
 
-from six.moves import range
+# import traceback
+
+from six.moves import range # type: ignore
 
 from . import yencode
 from . import utils
-
-#importing printlog() wrapper
-from .debug import printlog
 
 ENCODED_HEADER = b"[SOB]"
 ENCODED_TRAILER = b"[EOB]"
@@ -43,10 +44,14 @@ def update_crc(c_byte, crc):
     Update the CRC.
 
     :param c_byte: Character byte to add
+    :type c_byte: int
     :param crc: CRC to update
+    :type crc: int
     :returns: 16 bit CRC
+    :rtype: int
     '''
     # python 2 compatibility hack
+    # :type c_byte: may be str for python2
     if isinstance(c_byte, str):
         c_byte = ord(c_byte)
     for _ in range(0, 8):
@@ -73,8 +78,11 @@ def calc_checksum(data):
     Calculate a checksum
 
     :param data: Data to checksum
+    :type data: bytes
     :returns: checksum
+    :rtype: int
     '''
+    # :type data: is str for python2
     checksum = 0
     for i in data:
         checksum = update_crc(i, checksum)
@@ -89,8 +97,11 @@ def encode(data):
     yencode data.
 
     :param data: Data to encode
+    :type data: bytes
     :returns: encoded data
+    :rtype: bytes
     '''
+    # :type data: str for python2
     return yencode.yencode_buffer(data)
 
 
@@ -99,8 +110,11 @@ def decode(data):
     ydecode data.
 
     :param data: Data to decode
+    :type data: bytes
     :returns: decoded data
+    :rtype: bytes
     '''
+    # :type data: bytearray for python2
     return yencode.ydecode_buffer(data)
 
 
@@ -113,6 +127,7 @@ class DDT2Frame():
     csl = 2
 
     def __init__(self):
+        self.logger = logging.getLogger("DDT2Frame")
         self.seq = 0
         self.session = 0
         self.type = 0
@@ -135,9 +150,11 @@ class DDT2Frame():
         Get Transmit bps
 
         :returns: bps value
+        :rtype: float
         '''
         if not self._xmit_e:
-            printlog("Ddt2", "      : Block not sent, can't determine BPS!")
+            self.logger.info("get_xmit_bps: Block not sent, "
+                             "can't determine BPS!")
             return 0
 
         if self._xmit_s == self._xmit_e:
@@ -150,6 +167,7 @@ class DDT2Frame():
         set compression.
 
         :params compress: Default True for compressed data
+        :type compress: bool
         '''
         self.compress = compress
 
@@ -158,19 +176,20 @@ class DDT2Frame():
         get packed data
 
         :returns: packed data
+        :rtype: bytes
         '''
+        # :rtype: str for python2
         data = self.data
-        # python2 zlib.compress needs a string
-        # python3 zlib.compress needs a bytearray
-        # data should always be a bytearray, but we can not guarantee that
+        # python2 zlib.compress needs a str type
+        # python3 zlib.compress needs a bytes type
+        # data should always be a bytes, but we can not guarantee that
         # at this time.
         if sys.version_info[0] == 2:
             if not isinstance(self.data, str):
                 data = str(self.data)
         else:
             if isinstance(data, str):
-                # ISO-8859-1 is 8 bit tolerant and should be builtin.
-                data = self.data.encode('ISO-8859-1')
+                data = self.data.encode('utf-8', 'replace')
         if self.compress:
             data = zlib.compress(data, 9)
         else:
@@ -178,15 +197,18 @@ class DDT2Frame():
 
         length = len(data)
 
+        # self.s_station/d_station need to be str type
+        # On python 3, struct needs them to byte type,
+        # so we need to convert them.
         if sys.version_info[0] > 2:
             s_sta = self.s_station
             d_sta = self.d_station
             if isinstance(self.s_station, str):
-                s_sta = self.s_station.encode('ISO-8859-1')
+                s_sta = self.s_station.encode('utf-8', 'replace')
             if isinstance(self.d_station, str):
-                d_sta = self.d_station.encode('ISO-8859-1')
-            s_station = bytearray(s_sta.ljust(8, b"~"))
-            d_station = bytearray(d_sta.ljust(8, b"~"))
+                d_sta = self.d_station.encode('utf-8', 'replace')
+            s_station = bytes(s_sta.ljust(8, b"~"))
+            d_station = bytes(d_sta.ljust(8, b"~"))
         else:
             s_station = self.s_station.ljust(8, "~")
             d_station = self.d_station.ljust(8, "~")
@@ -213,17 +235,27 @@ class DDT2Frame():
                           s_station,
                           d_station)
 
+        self.logger.debug("get_packed: seq:%s session:%s type:%s",
+                          self.seq, self.session, self.type)
+        # utils.hexprintlog(val)
+        # if self.session == 0 and self.type not in [1, 2]:
+        #    traceback.print_stack()
+
         self._xmit_z = len(val) + len(data)
 
         return val + data
 
+    # pylint: disable=too-many-branches
     def unpack(self, val):
         '''
         unpack a frame
 
         :param val: Frame to unpack
+        :type val: bytes
         :returns: True if frame unpacked
+        :rtype: bool
         '''
+        # :type val: bytearray for python2
         magic = val[0]
         # python2 compatibility hack
         if isinstance(magic, str):
@@ -233,7 +265,7 @@ class DDT2Frame():
         elif magic == 0x22:
             self.compress = False
         else:
-            printlog(("Ddt2      : Magic 0x%X not recognized" % magic))
+            self.logger.info("unpack: Magic 0x%X not recognized", magic)
             return False
 
         header = val[:25]
@@ -241,7 +273,10 @@ class DDT2Frame():
 
         (magic, self.seq, self.session, self.type,
          checksum, length,
-         self.s_station, self.d_station) = struct.unpack(self.format, header)
+         s_station, d_station) = struct.unpack(self.format, header)
+        self.logger.debug("unpack: seq:%s session:%s type:%s",
+                          self.seq, self.session, self.type)
+        # utils.hexprintlog(header)
         _header = struct.pack(self.format,
                               magic,
                               self.seq,
@@ -249,17 +284,25 @@ class DDT2Frame():
                               self.type,
                               0,
                               length,
-                              self.s_station,
-                              self.d_station)
+                              s_station,
+                              d_station)
 
         _checksum = calc_checksum(_header + data)
-        self.s_station = self.s_station.replace(b"~", b"")
-        self.d_station = self.d_station.replace(b"~", b"")
+
+        s_station = s_station.replace(b"~", b"")
+        d_station = d_station.replace(b"~", b"")
+        if isinstance(s_station, str):
+            self.s_station = s_station
+        else:
+            self.s_station = s_station.decode('utf-8', 'replace')
+        if isinstance(d_station, str):
+            self.d_station = d_station
+        else:
+            self.d_station = d_station.decode('utf-8', 'replace')
 
         if _checksum != checksum:
-            printlog("Ddt2",
-                     "      : Checksum failed: %s != %s" %
-                     (checksum, _checksum))
+            self.logger.info("unpack: Checksum failed: %s != %s",
+                             checksum, _checksum)
             return False
 
         if self.compress:
@@ -267,7 +310,7 @@ class DDT2Frame():
                 self.data = zlib.decompress(data)
             else:
                 comp_data = zlib.decompress(str(data))
-                self.data = bytearray(comp_data)
+                self.data = bytes(comp_data)
         else:
             self.data = data
 
@@ -282,8 +325,8 @@ class DDT2Frame():
         # data = utils.filter_to_ascii(self.data[:20])
         # tolto il limite dei 20 caratteri
         data = utils.filter_to_ascii(self.data)
-        # printlog("-----------" #)
-        # printlog("Ddt2      : DDT2%s: %i:%i:%i %s->%s (%s...[%i])" % (c,
+        # self.logger.info("-----------")
+        # self.logger.info("DDT2%s: %i:%i:%i %s->%s (%s...[%i])" c,
         #                                                self.seq,
         #                                                self.session,
         #                                                self.type,
@@ -306,6 +349,7 @@ class DDT2Frame():
         Get a copy of the frame.
 
         :returns: copy of the frame
+        :rtype: :class:`DDT2Frame`
         '''
         frame = self.__class__()
         frame.seq = self.seq
@@ -320,6 +364,10 @@ class DDT2Frame():
 
 class DDT2EncodedFrame(DDT2Frame):
     '''DDT2 Encoded Frame'''
+
+    def __init__(self):
+        DDT2Frame.__init__(self)
+        self.logger = logging.getLogger("DDT2EncodedFrame")
 
     def get_packed(self):
         '''
@@ -338,25 +386,28 @@ class DDT2EncodedFrame(DDT2Frame):
         unpack frame.
 
         :param val: Frame to unpack
-        :returns: Unpacked frame or False if can not unpack frame
+        :type val: bytes
+        :returns: False if can not unpack frame
+        :rtype: bool
         '''
         try:
             if (sys.version_info[0] > 2) and isinstance(val, str):
-                val = val.encode('ISO-8859-1')
+                val = val.encode('utf-8', 'replace')
 
             h_index = val.index(ENCODED_HEADER) + len(ENCODED_TRAILER)
             t_index = val.rindex(ENCODED_TRAILER)
             payload = val[h_index:t_index]
         # pylint: disable=broad-except
-        except Exception as err:
-            printlog("Ddt2      : Block has no header/trailer: %s" % err)
+        except Exception:
+            self.logger.info("unpack: Block has no header/trailer",
+                             exc_info=True)
             return False
 
         try:
             decoded = decode(payload)
         # pylint: disable=broad-except
-        except Exception as err:
-            printlog("Ddt2      : Unable to decode frame: %s" % err)
+        except Exception:
+            self.logger.info("unpack: Unable to decode frame", exc_info=True)
             return False
 
         return DDT2Frame.unpack(self, decoded)
@@ -365,27 +416,39 @@ class DDT2EncodedFrame(DDT2Frame):
 class DDT2RawData(DDT2Frame):
     '''DDT2 Raw Data'''
 
+    def __init__(self):
+        DDT2Frame.__init__(self)
+        self.logger = logging.getLogger("DDT2RawFrame")
+
     def get_packed(self):
         '''
         Get packed raw data.
         :returns: data
+        :rtype: bytes
         '''
         return self.data
 
-    def unpack(self, _string):
+    def unpack(self, _val):
         '''
         unpack raw data.
 
-        :param _string: Unused
+        :param _val: Unused
         :returns: data
+        :rtype: bytes
         '''
+        # WB8TYW: This appears to be broken.
+        # the data member is directly updated to it appears to work
+        # once the data is populated, it will be interpreted as a true value.
         return self.data
 
-def test_symmetric(compress=True):
+
+def test_symmetric(logger, compress=True):
     '''
     Test Symmetric operations.
 
+    :param logger: Logger object
     :param compress: Test with compression
+    :type compress: bool
     '''
     fin = DDT2EncodedFrame()
     fin.type = 1
@@ -396,29 +459,41 @@ def test_symmetric(compress=True):
     fin.data = b"This is a test"
     fin.set_compress(compress)
     packed_frame = fin.get_packed()
-
-    printlog(("Ddt2      :%s" % packed_frame))
+    logger.info("packed_frame: %s", packed_frame)
 
     fout = DDT2EncodedFrame()
     fout.unpack(packed_frame)
 
-    #printlog((fout.__dict__)
-    printlog(("Ddt2      :%s" % fout))
+    # logger.info(fout.__dict__)
+    logger.info("fout: %s", fout)
 
-def test_crap():
-    '''Test routine'''
+
+def test_crap(logger):
+    '''
+    Test routine.
+
+    :param logger: Logger object
+    '''
     frame = DDT2EncodedFrame()
     try:
         if frame.unpack(b"[SOB]foobar[EOB]"):
-            printlog("Ddt2", "      : FAIL")
+            logger.info("FAIL")
         else:
-            printlog("Ddt2", "      : PASS")
+            logger.info("PASS")
     # pylint: disable=broad-except
-    except Exception as err:
-        printlog("Generic Exception %s %s" % (type(err), err))
-        printlog("Ddt2", "      : PASS")
+    except Exception:
+        logger.info("Generic Exception", exc_info=True)
+        logger.info("PASS")
+
+
+def main():
+    '''Unit Test.'''
+    logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
+                        level=logging.INFO)
+    logger = logging.getLogger("DDT2.test")
+    test_symmetric(logger)
+    test_symmetric(logger, True)
+    test_crap(logger)
 
 if __name__ == "__main__":
-    test_symmetric()
-    test_symmetric(False)
-    test_crap()
+    main()


### PR DESCRIPTION
Need to make sure that the d_station and s_station are of type str
or it causes them to be auto converted from bytes type with a "b" prefix.

d_rats/ddt2.py:
  Improve Docstrings.
  Converted to use logging module
  Fix str->bytes conversions to use "utf-8" for consistency
  Need to make sure that the d_station and s_station are type str