### PR TITLE
make geocode_ui geopy optional for python2

### DIFF
--- a/d_rats/geocode_ui.py
+++ b/d_rats/geocode_ui.py
@@ -30,6 +30,9 @@ try:
     from geopy import geocoders
 except ModuleNotFoundError:
     pass
+# python2 compatibility
+except ImportError:
+    pass
 
 import gi
 gi.require_version("Gtk", "3.0")


### PR DESCRIPTION
geopy is not available as a signed package on all
plaforms that I can test on.

Nothing in d-rats should require a module installed
from pypi via pip.

d_rats/geocode_ui.py:
  Handle python2 import failure while we still
  have python2 compatibility.