### PR TITLE
d_rats.py python3 fixes

### DIFF
--- a/d-rats_repeater.py
+++ b/d-rats_repeater.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-many-lines, invalid-name
 #
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
-# Python3 conversion Copyright 2012 John Malmberg <wb8tyw@qsl.net>
+# Python3 conversion Copyright 2022 John Malmberg <wb8tyw@qsl.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
d_rats.py:
  Convert to logging module.
  Improve Docstrings.
  Fix gettext import for pylance.
  Replace deprecated optparse module with argparse.

d_rats_repeater.py:
  Fix typo in copyright date.