### PR TITLE
Minor gps logging fix

### DIFF
--- a/d_rats/gps.py
+++ b/d_rats/gps.py
@@ -537,12 +537,15 @@ class GPSPosition():
     :type station: str
     '''
 
-    def __init__(self, lat=0, lon=0, station="UNKNOWN"):
+    def __init__(self, lat=0, lon=0, station=None):
         self.logger = logging.getLogger("GPSPosition")
         self.valid = False
         self.altitude = 0
         self.satellites = 0
-        self.station = station
+        if station:
+            self.station = station
+        else:
+            self.station = _("UNKNOWN")
         self.comment = ""
         self.current = None
         self.date = datetime.datetime.now()
@@ -958,7 +961,7 @@ class NMEAGPSPosition(GPSPosition):
     :raises: GpsGpggaException classes on error.
     '''
 
-    def __init__(self, sentence, station=_("UNKNOWN")):
+    def __init__(self, sentence, station=None):
         GPSPosition.__init__(self)
         self.logger = logging.getLogger("NMEAGPSPosition")
         self.latitude = None
@@ -1558,16 +1561,18 @@ class StaticGPSSource(GPSSource):
     :type lon: float
     :param alt: Altitude, default 0
     :type alt: float
+    :param station: Station for source, default 'Unknown'
+    :type station: str
     '''
 
     # pylint: disable=super-init-not-called
-    def __init__(self, lat, lon, alt=0):
+    def __init__(self, lat, lon, alt=0, station=None):
         self.logger = logging.getLogger("StaticGPSSource")
         self.lat = lat
         self.lon = lon
         self.alt = alt
 
-        self.position = GPSPosition(self.lat, self.lon)
+        self.position = GPSPosition(self.lat, self.lon, station)
         self.position.altitude = int(float(alt))
         if EARTH_UNITS == "mi":
             # This is kinda ugly, but assume we're given altitude in the same

--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -1452,6 +1452,7 @@ class MainApp(Gtk.Application):
         :return: Map source
         :rtype: :class:`StaticGPSSource`
         '''
+        # Note, nothing seems to be using the return value.
         tstation = self.mainwindow.tabs["event"].last_event_time(fix.station)
         if (time.time() - tstation) > 300:
             self.mainwindow.tabs["event"].finalize_last(fix.station)
@@ -1538,7 +1539,8 @@ class MainApp(Gtk.Application):
                 "__incoming_gps_fix:"
                 " Export to external mapserver not active: %s",
                 mapserver_active)
-        return gps.StaticGPSSource(fix.latitude, fix.longitude, fix.altitude)
+        return gps.StaticGPSSource(fix.latitude, fix.longitude,
+                                   fix.altitude, fix.station)
 
     def __station_status(self, _obj, sta, stat, msg, port):
         '''


### PR DESCRIPTION
It just seemed wrong to report a station of  "UNKNOWN" when logging an incoming
GPS position from a known station.

d_rats/gps.py:
  Make default of _('UNKNOWN') consistent.
  Allow a StaticGPSSource to specify an optional callsign

d_rats/mainapp.py:
  __incoming_gps_fix: Add station callsign to logged response.