### PR TITLE
Attempt to improve point plotting on map

### DIFF
--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -53,7 +53,7 @@ if not '_' in locals():
     _ = gettext.gettext
 
 
-# We have more than 7 instance attributes
+# We have more than 7 instance attributes and more than 20 public methods
 # pylint: disable=too-many-instance-attributes, too-many-public-methods
 class MapWindow(Gtk.ApplicationWindow):
     '''
@@ -907,7 +907,7 @@ class MapWindow(Gtk.ApplicationWindow):
 
     # Called by mainapp
     @staticmethod
-    def set_base_dir(base_dir, map_url, map_key=None):
+    def set_base_dir(base_dir, map_url, map_key):
         '''
         Set Base Directory.
 


### PR DESCRIPTION
d_rats/map/mapdraw.py:
  Fix center based recalculations to be based on both center or zoom changes.
  Add get_map_base() method, for possible future use.
  Add attempt at zoom specific point plotting corrections so that
  the position reported by my GPS is plotted correctly on the map.

d_rats/maptile.py:
  Add some properties to the MapTile class to try to eliminate fudge factors.
  For set_map_info method, map_url_key no longer optional.
  Fix deg2num method to be inverse of num2deg method.
  Add deg2tile method to return the map tile.
  Add deg2pixel method as an attempt to return a pixel coordinate.
  Handle math overflow in num2deg method.
  Fix to handle odd error, or possible threading race condition where
  os.path.isdir returns that a directory does not exist, yet os.makedirs
  fails because the directory does exist.
  Fix __add__ method to handle wrapping around map boundaries.
  Fix __contains__ method to handle tiles anywhere on map.

d_rats/map/mapwidget.py:
  Add LAT_MAX and LON_MAX constants
  Fix handling of latitude / longitude changing sign in displayed map.
  Restore older fudging algorithm.

d_rats/map/mapwindow.py:
  For set_base_dir method, the map_key is no longer optional.