### PR TITLE
Fix Gtk.TextTag in spell module

### DIFF
--- a/d_rats/spell.py
+++ b/d_rats/spell.py
@@ -225,7 +225,7 @@ def prepare_TextBuffer(buf):
     from gi.repository import Pango
 
     tags = buf.get_tag_table()
-    tag = Gtk.TextTag("misspelled")
+    tag = Gtk.TextTag.new("misspelled")
     tag.set_property("underline", Pango.UNDERLINE_SINGLE)
     tag.set_property("underline-set", True)
     tag.set_property("foreground", "red")


### PR DESCRIPTION
d_rats/spell.py:
  Make Gtk.TextTag use new method to create to match
  other usage in d-rats