### PR TITLE
fix(config) Improve Config settings

### DIFF
--- a/d_rats/config.py
+++ b/d_rats/config.py
@@ -3,7 +3,7 @@
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
 # review 2015-2020 Maurizio Andreotti  <iz2lxi@yahoo.it>
-# Copyright 2021 John. E. Malmberg - Python3 Conversion
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -994,6 +994,7 @@ class DratsPanel(Gtk.Grid):
                     hbox.pack_start(i, 0, 0, 0)
                 else:
                     hbox.pack_start(i, 1, 1, 0)
+                    i.set_hexpand(True)
                 self.vals.append(i)
             else:
                 hbox.pack_start(i, 0, 0, 0)

--- a/ui/addport.glade
+++ b/ui/addport.glade
@@ -90,7 +90,7 @@
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -181,6 +181,7 @@
                                 <child internal-child="entry">
                                   <object class="GtkEntry">
                                     <property name="can_focus">False</property>
+                                    <property name="width_chars">24</property>
                                   </object>
                                 </child>
                               </object>
@@ -217,7 +218,7 @@
                           </object>
                           <packing>
                             <property name="menu_label">serial</property>
-                            <property name="tab_fill">False</property>
+                            <property name="tab_expand">True</property>
                           </packing>
                         </child>
                         <child>
@@ -240,6 +241,7 @@
                               <object class="GtkEntry" id="net_host">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
+                                <property name="width_chars">80</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
@@ -297,7 +299,7 @@
                           <packing>
                             <property name="menu_label">network</property>
                             <property name="position">1</property>
-                            <property name="tab_fill">False</property>
+                            <property name="tab_expand">True</property>
                           </packing>
                         </child>
                         <child>
@@ -398,6 +400,7 @@ passed through a digipeater</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="tooltip_text" translatable="yes">AX.25 Digi path (CALL1,CALL2,...)</property>
+                                <property name="width_chars">80</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
@@ -453,7 +456,7 @@ the TNC (not the rate over the air)</property>
                           <packing>
                             <property name="menu_label">tnc</property>
                             <property name="position">2</property>
-                            <property name="tab_fill">False</property>
+                            <property name="tab_expand">True</property>
                           </packing>
                         </child>
                         <child>
@@ -476,7 +479,7 @@ the TNC (not the rate over the air)</property>
                           <packing>
                             <property name="menu_label">dongle</property>
                             <property name="position">3</property>
-                            <property name="tab_fill">False</property>
+                            <property name="tab_expand">True</property>
                           </packing>
                         </child>
                         <child>
@@ -498,6 +501,7 @@ the TNC (not the rate over the air)</property>
                               <object class="GtkEntry" id="agw_addr">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
+                                <property name="width_chars">35</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
@@ -597,7 +601,7 @@ the TNC (not the rate over the air)</property>
                           <packing>
                             <property name="menu_label">agwpe</property>
                             <property name="position">4</property>
-                            <property name="tab_fill">False</property>
+                            <property name="tab_expand">True</property>
                           </packing>
                         </child>
                       </object>


### PR DESCRIPTION
wb8tyw_issue: 63

d_rats/config.py:
  In DratsPanel.make_view method, set panel to fill the width
  of the container.

d_rats/miscwidgets.py:
  In class KeyedListWidget, set the view to fill the width of
  the container.
  In class KeyedListWidget _make_view method, fix field expansion.

ui/addport.glade:
  set some field widths for radio entries.