### PR TITLE
fix(qst): Fix QST sending

### DIFF
--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -720,7 +720,9 @@ class MainApp(Gtk.Application):
         Chat session.
 
         :param portname: Port name for session
+        :type portname: str
         :returns: Chat Session object
+        :rtype: :class:`sessions.chat.ChatSession`
         '''
         return self.smgr[portname][0].get_session(lid=1)
 
@@ -1286,9 +1288,13 @@ class MainApp(Gtk.Application):
         listening from the arriving messages
 
         :param _obj: unused
+        :type _obj: :class:`ui.main_chat.ChatTab`
         :param station: Station
+        :type station: :class:`str`
         :param port: Radio port
+        :type port: :class:`str`
         :param msg: Chat message
+        :type msg: :class:`str`
         :param raw: True if raw mode
         :type raw: bool
         '''

--- a/d_rats/miscwidgets.py
+++ b/d_rats/miscwidgets.py
@@ -1157,6 +1157,8 @@ def make_choice(options, editable=True, default=None):
     :param editable: Default True
     :type editable: bool
     :param default: Default None
+    :returns: selection dialog
+    :rtype: :class:`Gtk.ComboBox.Text`
     '''
     logger = logging.getLogger("make_choice")
     if editable:


### PR DESCRIPTION
d_rats/qst.py:
  Resolved some pylint flagged issues.
  Resolved all bare/broad exceptions.
  Convert get_source and get_station to static methods.
  Rename prompt_for_DPRS method to comply with python naming.
  Fix QSTEditDialog to get frequency setting.

d_rats/mainapp.py:
  Improve some Docstrings.

d_rats/miscwidgets.py:
  Improve some Docstrings.

d_rats/ui/main_chat.py:
  Resolved some pylint flagged issues.
  Resolved all bare/broad exceptions.
  In ChatQST._toggle_qst, Fix changing QST status.
  Convert ChatQST._remaining_for to a static method.
  Convert ChatTab._maybe_highlight_header to a static method.
  In ChatTAb._send_msg and ChatTab._bcast_file methods:
    Add a Docstring.
    Fix selecting the current active sending port.
  In ChatTab._enter_to_send methods:
    Add a Docstring.
    Use Gdk constants instead of "magic" numbers.
  In ChatTab._configure_filters method, replace unsafe eval() call.
  In ChatTab.get_selected_port, Fix getting destination port.