### PR TITLE
fix(map) Fix tile threading

### DIFF
--- a/d_rats/map/mapdraw.py
+++ b/d_rats/map/mapdraw.py
@@ -404,12 +404,9 @@ class MapDraw():
                     self.draw_tile(None,
                                    tilesize * i,
                                    tilesize * j)
-                    tile.threaded_fetch(self.draw_tile,
-                                        tilesize * i,
-                                        tilesize * j)
+                    tile.threaded_fetch(self.map_widget)
                 self.progress(message)
                 self.map_widget.map_tiles.append(tile)
-        #self.emit("new-tiles-loaded")
 
     # pylint: disable=too-many-locals
     def scale(self):


### PR DESCRIPTION
A Gtk Widget call can not be made inside of a Python Thread.

d_rats/map/mapdraw.py:
  In expose_map method, pass widget reference, not a callback.

d_rats/map/maptile.py:
  Throttle queuing map draw events on tile updates
  When a threaded fetch completes, it now adds a delayed
  map queue event, if there is not one pending.
  Note this delayed event does not actually seem to be needed
  as the map seems to update just before the event is queued.