### PR TITLE
fix:(comm): TNC and Serial Port fixes

### DIFF
--- a/d_rats/dplatform.py
+++ b/d_rats/dplatform.py
@@ -693,7 +693,8 @@ class Win32Platform(Platform):
                 port = None
 
             except pywintypes.error as err:
-                if err.args[0] != 2:
+                # Error code 5 Apparently if the serial port is in use.
+                if err.args[0] not in [2, 5]:
                     self.logger.info("list_serial_ports", exc_info=True)
 
         return ports


### PR DESCRIPTION
Make sure serial radio and TNC modes work.

d_rats/comm.py:
  Convert to python3.
  Improve Docstrings.
  Fix some broad exceptions.
  Fix DTR and RTS to be set according to standards.
  in kiss_recv_frame module, discard the 2 fcs check bytes.

d_rats/dplatform.py:
  Fix handling of exception when serial port is in use.