### PR TITLE
fix:(file) Fix file transfers

### DIFF
--- a/d_rats/ui/main_files.py
+++ b/d_rats/ui/main_files.py
@@ -402,7 +402,7 @@ class FilesTab(MainWindowTab):
 
         if self._remote:
             station = self._remote.get_path()
-            self._remote.outstanding[fname] = os.stat(file_name).sit_size
+            self._remote.outstanding[fname] = os.stat(file_name).st_size
         else:
             station = ssel.get_active_text().upper()
 


### PR DESCRIPTION
Make sure endian is when using integers with pack or unpack or
transfers will not work on all platforms.

Have to specify little-endian here to be compatible with most of
the existing d-rats deployments, even though the normally
big endian would be used for a network.

d_rats/sessions/file.py:
  Need to explictly specify endian for integers transferred over the
  Network.

d_rats/ui/main_files.py:
  Fix a typo that broke file transfers.