### PR TITLE
fix(w2lk): Attempt to get w2lk working

### DIFF
--- a/d_rats/agw.py
+++ b/d_rats/agw.py
@@ -500,7 +500,6 @@ class AGW_AX25_Connection:
         def consume(count):
             buffer = self._inbuf[:count]
             self._inbuf = self._inbuf[count:]
-            self.logger.info("recv:consume: buffer %s", type(buffer))
             return buffer
 
         if length and length < len(self._inbuf):
@@ -765,6 +764,7 @@ def test_server(host="127.0.0.1", port=8000):
             agw.send_frame(frame)
         except (ConnectionError, OSError):
             global_logger.info("test_server: failed", exc_info=True)
+
 
 def main():
     '''Unit Test.'''

--- a/d_rats/sessions/rpc.py
+++ b/d_rats/sessions/rpc.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-many-lines
 #
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
-# Python3 update Copyright 2021 John Malmberg <wb8tyw@qsl.net>
+# Python3 update Copyright 2021-2022 John Malmberg <wb8tyw@qsl.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -177,7 +177,7 @@ class RPCJob(GObject.GObject):
     :type desc: str
     '''
     __gsignals__ = {
-        "state-change" : (GObject.SIGNAL_RUN_LAST,
+        "state-change" : (GObject.SignalFlags.RUN_LAST,
                           GObject.TYPE_NONE,
                           (GObject.TYPE_STRING, GObject.TYPE_PYOBJECT)),
         }

--- a/d_rats/sessions/sniff.py
+++ b/d_rats/sessions/sniff.py
@@ -1,7 +1,7 @@
 '''Sniff Packets'''
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
-# Python3 update Copyright 2021 John Malmberg <wb8tyw@qsl.net>
+# Python3 update Copyright 2021-2022 John Malmberg <wb8tyw@qsl.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,7 +51,7 @@ class SniffSession(stateless.StatelessSession, GObject.GObject):
     :param k: key word arguments
     '''
     __gsignals__ = {
-        "incoming_frame" : (GObject.SIGNAL_RUN_LAST,
+        "incoming_frame" : (GObject.SignalFlags.RUN_LAST,
                             GObject.TYPE_NONE,
                             (GObject.TYPE_STRING,    # Src
                              GObject.TYPE_STRING,    # Dst

--- a/d_rats/version.py
+++ b/d_rats/version.py
@@ -21,8 +21,10 @@ if __name__ == "__main__":
     lang.install()
     _ = lang.gettext
 
-
-DRATS_VERSION = "0.4.00 pre-release 1"
+# DRATS_VERSION_NUM can not have "-" characters in it.
+# That will break w2lk
+DRATS_VERSION_NUM = "0.4.00"
+DRATS_VERSION = DRATS_VERSION_NUM + " pre-release1"
 DRATS_NAME = "d-rats"
 DRATS_DESCRIPTION = "D-RATS"
 DRATS_LONG_DESCRIPTION = "A communications tool for D-STAR"


### PR DESCRIPTION
The w2lk stuff depends a bit on e-mail, which has not yet been
verified as working on python3.

d_rats/agw.py:
  Remove extra diagnostic logging message
  Whitespace fix

d_rats/sessions/rpc.py:
d_rats/sessions/sniff.py:
  Fix deprecated GObject.SIGNAL_RUN_LAST

d_rats/version.py:
  Add DRATS_VERSION_NUM to comply with w2lk restrictions on
  version numbering.

d_rats/wl2k.py:
  Convert to python3.
  Improve Docstrings.
  Add simple test server.