### PR TITLE
fix(mailsrv) Get Mailsvr module working

### DIFF
--- a/d_rats/emailgw.py
+++ b/d_rats/emailgw.py
@@ -23,22 +23,18 @@ from __future__ import print_function
 import os
 import threading
 import poplib
-import smtplib
-import email
+# import smtplib
+
 import re
 import random
 import time
-from six.moves import range
-try:
-    from email.mime.multipart import MIMEMultipart
-    from email.mime.base import MIMEBase
-    from email.mime.text import MIMEText
-except ImportError:
-    # Python 2.4
-    from email import MIMEMultipart
-    from email import MIMEBase
-    from email import MIMEText
-    import rfc822
+
+import email
+from email.utils import parseaddr
+# from email.message import Message
+# from email.mime.base import MIMEBase
+# from email.mime.multipart import MIMEMultipart
+# from email.mime.text import MIMEText
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -53,6 +49,11 @@ from .ui import main_events
 from . import signals
 from . import utils
 from . import msgrouting
+
+
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
 
 
 class EmailGatewayException(Exception):
@@ -81,7 +82,7 @@ def create_form_from_mail(config, mail, tmpfn):
     :param mail: Mail message
     :param tmpfn: Temporary filename
     :type tmpfn: str
-    :returns: Form
+    :returns: Form containing message
     :rtype: :class:`formgui.FormFile`
     :raises: :class:`NoUsablePartError` if unable to parse form
     '''
@@ -128,7 +129,7 @@ def create_form_from_mail(config, mail, tmpfn):
     else:
         printlog("emailgw", "   : Email from %s: %s" % (sender, subject))
 
-        recip, _addr = rfc822.parseaddr(mail.get("To", "UNKNOWN"))
+        recip, _addr = parseaddr(mail.get("To", "UNKNOWN"))
 
         efn = os.path.join(config.form_source_dir(), "email.xml")
         form = formgui.FormFile(efn)
@@ -527,7 +528,6 @@ def main():
             '''Get Boolean dummy function, returns False.'''
             return False
 
-    import gettext
     # pylint: disable=invalid-name
     lang = gettext.translation("D-RATS",
                                localedir="./locale",

--- a/d_rats/formgui.py
+++ b/d_rats/formgui.py
@@ -2,7 +2,7 @@
 '''Form GUI'''
 # pylint: disable=too-many-lines
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
-# Copyright 2021 John. E. Malmberg - Python3 Conversion
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1079,14 +1079,14 @@ class FormField():
         '''Update node.'''
         self.entry.update_node()
 
-# Need to inherit from object here for python2 compatibility
+
 # pylint: disable=too-many-public-methods, too-many-instance-attributes
-# pylint: disable=useless-object-inheritance
-class FormFile(object):
+class FormFile():
     '''
     Form File.
 
     :param filename: File name for form
+    :type filename: str
     :raises: FormguiFormfileEmpty exception
     '''
     def __init__(self, filename):
@@ -1116,6 +1116,7 @@ class FormFile(object):
         Save to file.
 
         :param filename: File name to save to
+        :type filename: str
         '''
         self.doc.write(filename)
 
@@ -1124,6 +1125,7 @@ class FormFile(object):
         Export to string.
 
         :returns: result of writing the string
+        :rtype: str
         '''
         form_writer = HTMLFormWriter(self.ident, self.xsl_dir)
         return form_writer.writeString(self.doc)
@@ -1132,9 +1134,11 @@ class FormFile(object):
         '''
         Get xml.
 
-        :returns: XML serialized into a string'''
+        :returns: XML serialized into a string
+        :rtype: str
+        '''
         root = self.doc.getroot()
-        return root.tostring()
+        return etree.tostring(root)
 
     def process_form(self, doc):
         '''

--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -925,7 +925,7 @@ class MainApp(Gtk.Application):
 
         try:
             if self.config.getboolean("settings", "msg_smtp_server"):
-                smtpsrv = mailsrv.DRATS_SMTPServerThread(self.config)
+                smtpsrv = mailsrv.DratsSMTPServerThread(self.config)
                 smtpsrv.start()
                 self.mail_threads["SMTPSRV"] = smtpsrv
         # pylint: disable=broad-except
@@ -939,7 +939,7 @@ class MainApp(Gtk.Application):
 
         try:
             if self.config.getboolean("settings", "msg_pop3_server"):
-                pop3srv = mailsrv.DRATS_POP3ServerThread(self.config)
+                pop3srv = mailsrv.DratsPOP3ServerThread(self.config)
                 pop3srv.start()
                 self.mail_threads["POP3SRV"] = pop3srv
         # pylint: disable=broad-except

--- a/d_rats/ui/main_messages.py
+++ b/d_rats/ui/main_messages.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-many-lines
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
-# Copyright 2021 John. E. Malmberg - Python3 Conversion
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -39,7 +39,7 @@ from gi.repository import Pango
 # pyright: reportMissingModuleSource=false
 from six.moves.configparser import ConfigParser
 from six.moves.configparser import DuplicateSectionError
-
+from six.moves.configparser import NoSectionError
 from d_rats.ui.main_common import MainWindowElement, MainWindowTab
 from d_rats.ui.main_common import prompt_for_station, \
     display_error, prompt_for_string, set_toolbar_buttons
@@ -133,9 +133,7 @@ class MessageFolderInfo():
 
         try:
             return self._config.get(filename, prop)
-        # pylint: disable=broad-except
-        except Exception:
-            self.logger.info("getprop broad-except", exc_info=True)
+        except NoSectionError:
             return _("Unknown")
 
     def get_msg_subject(self, filename):


### PR DESCRIPTION
Get the mailsrv module working with Python 3

d_rats/emailgw.py:
  Remove some python2 compatibility code.
  Fix gettext import for pylance warnings.
  Only fixed sections used by mailsrv.

d_rats/formgui.py:
  Fix FormFile.get_xml() method.

d_rats/mailsrv.py:
  Convert to printlog.
  Convert to use bytes type were needed.

d_rats/mainapp.py:
  Corrected invalid names for mailsrv classes.