### PR TITLE
fix(GLib): GOobject.idle_add deprecated

### DIFF
--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -643,7 +643,7 @@ class MainApp(Gtk.Application):
         def transport_msg(msg):
             _port = name
             event = main_events.Event(None, "%s: %s" % (_port, msg))
-            GObject.idle_add(self.mainwindow.tabs["event"].event, event)
+            GLib.idle_add(self.mainwindow.tabs["event"].event, event)
 
         transport_args = {
             "compat" : raw,
@@ -1205,7 +1205,7 @@ class MainApp(Gtk.Application):
             self.mainwindow.tabs["chat"].display_line(line, incoming, color,
                                                       **kwargs)
 
-        GObject.idle_add(do_incoming)
+        GLib.idle_add(do_incoming)
 
 # ---------- STANDARD SIGNAL HANDLERS --------------------
 

--- a/d_rats/map_sources.py
+++ b/d_rats/map_sources.py
@@ -33,6 +33,7 @@ from six.moves.configparser import NoOptionError # type: ignore
 
 import gi
 gi.require_version("Gtk", "3.0")
+from gi.repository import GLib
 from gi.repository import GObject
 
 from . import utils
@@ -249,7 +250,7 @@ class MapPointThreaded(MapPoint):
 
     def __thread_fn(self):
         self.do_update()
-        GObject.idle_add(self.emit, "updated", "FOO")
+        GLib.idle_add(self.emit, "updated", "FOO")
 
 
 class MapUSGSRiver(MapPointThreaded):

--- a/d_rats/msgrouting.py
+++ b/d_rats/msgrouting.py
@@ -1,7 +1,7 @@
 #
 '''Message Routing'''
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
-# Copyright 2021 John. E. Malmberg - Python3 Conversion
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,6 +43,7 @@ except ImportError:
 
 import gi
 gi.require_version("Gtk", "3.0")
+from gi.repository import GLib
 from gi.repository import GObject
 
 from . import formgui
@@ -71,7 +72,7 @@ CALL_TIMEOUT_RETRY = 300
 
 MSG_LOCK_LOCK = threading.Lock()
 
-# pylint: disable=invaid-name
+# pylint: disable=invalid-name
 global_logger = logging.getLogger("MsgRouting")
 
 def __msg_lockfile(fname):
@@ -215,8 +216,12 @@ def form_to_email(config, msgfn, replyto=None):
 
     :param config: Config object
     :type config: :class:`DratsConfig`
-    :param msgfn: Message Form
+    :param msgfn: Message file name
+    :type msgfn: str
     :param replyto: Optional replyto destination
+    :type replyto: str
+    :returns: Email data
+    :rtype: :class:`MIMEMultipart`
     '''
     form = formgui.FormFile(msgfn)
     form.configure(config)
@@ -341,7 +346,7 @@ class MessageRouter(GObject.GObject):
         self.__enabled = False
 
     def _emit(self, signal, *args):
-        GObject.idle_add(self.emit, signal, *args)
+        GLib.idle_add(self.emit, signal, *args)
 
     def __proxy_emit(self, signal):
         def handler(_obj, *args):

--- a/d_rats/qst.py
+++ b/d_rats/qst.py
@@ -31,6 +31,7 @@ import urllib
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
+from gi.repository import GLib
 from gi.repository import GObject
 
 if not '_' in locals():
@@ -405,7 +406,7 @@ class QSTThreadedText(QSTText):
             self.logger.info("Skipping QST because no data was returned")
             return
 
-        GObject.idle_add(self.emit, "qst-fired",
+        GLib.idle_add(self.emit, "qst-fired",
                          "%s%s" % (self.prefix, msg), self.key)
 
     def fire(self):

--- a/d_rats/session_coordinator.py
+++ b/d_rats/session_coordinator.py
@@ -2,7 +2,7 @@
 '''Session Coordinator'''
 #
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
-# Copyright 2021 John. E. Malmberg - Python3 Conversion
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ import os
 
 import gi
 gi.require_version("Gtk", "3.0")
+from gi.repository import GLib
 from gi.repository import GObject
 
 from d_rats.sessions import base
@@ -451,7 +452,7 @@ class SessionCoordinator(GObject.GObject):
         self.socket_listeners = {}
 
     def _emit(self, signal, *args):
-        GObject.idle_add(self.emit, signal, *args)
+        GLib.idle_add(self.emit, signal, *args)
 
     def session_status(self, session, msg):
         '''
@@ -708,7 +709,7 @@ class SessionCoordinator(GObject.GObject):
         :param direction: Direction of session
         :type direction: str
         '''
-        GObject.idle_add(self._new_session, session_type, session, direction)
+        GLib.idle_add(self._new_session, session_type, session, direction)
 
     def end_session(self, ident):
         '''

--- a/d_rats/sessions/chat.py
+++ b/d_rats/sessions/chat.py
@@ -1,7 +1,7 @@
 '''Sessions Chat.'''
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
-# Python3 update Copyright 2021 John Malmberg <wb8tyw@qsl.net>
+# Python3 update Copyright 2021-2022 John Malmberg <wb8tyw@qsl.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,6 +25,7 @@ import time
 
 import gi
 gi.require_version("Gtk", "3.0")
+from gi.repository import GLib
 from gi.repository import GObject
 
 from d_rats import signals, dplatform, gps, utils, station_status
@@ -107,7 +108,7 @@ class ChatSession(stateless.StatelessSession, GObject.GObject):
                                                    pform.os_version_string())
 
     def _emit(self, signal, *args):
-        GObject.idle_add(self.emit, signal, *args)
+        GLib.idle_add(self.emit, signal, *args)
 
     def _incoming_chat(self, frame):
         self._emit("incoming-chat-message",

--- a/d_rats/sessions/rpc.py
+++ b/d_rats/sessions/rpc.py
@@ -218,7 +218,7 @@ class RPCJob(GObject.GObject):
         if not isinstance(result, dict):
             raise RPCResultNotDict("Value of result property must be dict")
         if state in self.STATES:
-            GObject.idle_add(self.emit, "state-change", state, result)
+            GLib.idle_add(self.emit, "state-change", state, result)
         else:
             raise RPCInvalidStatus("Invalid status `%s'" % state)
 
@@ -738,7 +738,7 @@ class RPCActionSet(GObject.GObject):
     def __proxy_emit(self, signal):
         def handler(_obj, *args):
             self.logger.info("Proxy emit %s: %s", signal, args)
-            GObject.idle_add(self.emit, signal, *args)
+            GLib.idle_add(self.emit, signal, *args)
 
         return handler
 

--- a/d_rats/ui/main_chat.py
+++ b/d_rats/ui/main_chat.py
@@ -1277,7 +1277,7 @@ class ChatTab(MainWindowTab):
 
         # pylint: disable=unbalanced-tuple-unpacking
         entry, = self._getw("entry")
-        GObject.idle_add(entry.grab_focus)
+        GLib.idle_add(entry.grab_focus)
 
     def deselected(self):
         '''Process deselected tabs.'''

--- a/d_rats/ui/main_events.py
+++ b/d_rats/ui/main_events.py
@@ -25,6 +25,7 @@ from datetime import datetime
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
+from gi.repository import GLib
 from gi.repository import GObject
 
 from d_rats.ui.main_common import MainWindowTab
@@ -509,9 +510,9 @@ class EventTab(MainWindowTab):
             adj.set_value(adj.get_upper() - adj.get_page_size())
 
         if top_scrolled:
-            GObject.idle_add(top_scroll, adj)
+            GLib.idle_add(top_scroll, adj)
         elif bot_scrolled:
-            GObject.idle_add(bot_scroll, adj)
+            GLib.idle_add(bot_scroll, adj)
 
     def event(self, event):
         '''
@@ -519,7 +520,7 @@ class EventTab(MainWindowTab):
 
         :param event: Event to add
         '''
-        GObject.idle_add(self._event, event)
+        GLib.idle_add(self._event, event)
 
     def finalize_last(self, group):
         '''

--- a/d_rats/ui/main_files.py
+++ b/d_rats/ui/main_files.py
@@ -290,7 +290,7 @@ class FilesTab(MainWindowTab):
         self.reconfigure()
 
     def _emit(self, *args):
-        GObject.idle_add(self.emit, *args)
+        GLib.idle_add(self.emit, *args)
 
     def _stop_throb(self):
         # pylint: disable=unbalanced-tuple-unpacking

--- a/d_rats/ui/main_messages.py
+++ b/d_rats/ui/main_messages.py
@@ -33,6 +33,7 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Pango
 
@@ -987,7 +988,7 @@ class MessageList(MainWindowElement):
         data = "\x01".join(msgs)
         byte_data = data.encode('ISO-8859-1')
         sel.set(sel.get_target(), 0, byte_data)
-        GObject.idle_add(self.refresh)
+        GLib.idle_add(self.refresh)
 
 
     def _update_message_info(self, msg_iter, force=False):

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -20,6 +20,7 @@ import random
 import gi
 
 gi.require_version("Gtk", "3.0")
+from gi.repository import GLib
 from gi.repository import GObject
 
 # sys.path.insert(0, "..")
@@ -984,7 +985,7 @@ class WinLinkThread(threading.Thread, GObject.GObject):
         '''
         Emit signal from thread.
         '''
-        GObject.idle_add(self.emit, *args)
+        GLib.idle_add(self.emit, *args)
 
     def _run_incoming(self):
         '''


### PR DESCRIPTION
d_rats/mainapp.py:
d_rats/map_sources.py:
d_rats/msgrouting.py:
d_rats/qst.py:
d_rats/session_coordinator.py:
d_rats/sessions/chat.py:
d_rats/sessions/rpc.py:
d_rats/ui/main_chat.py:
d_rats/ui/main_events.py:
d_rats/ui/main_files.py:
d_rats/ui/main_messages.py:
d_rats/wl2k.py:
  Use GLib.idle_add instead.