### PR TITLE
fix(msgrouting): Fix deadlocked messages

### DIFF
--- a/d_rats/mailsrv.py
+++ b/d_rats/mailsrv.py
@@ -82,7 +82,9 @@ class TCPServerThread(threading.Thread):
     def stop(self):
         '''Stop Server.'''
         self.__server.shutdown()
+        self.__server.server_close()
         self.logger.info("%s Shutdown", self.name)
+        self.join()
 
 
 class POP3Exception(Exception):

--- a/d_rats/ui/main_messages.py
+++ b/d_rats/ui/main_messages.py
@@ -40,6 +40,7 @@ from gi.repository import Pango
 # pyright: reportMissingModuleSource=false
 from six.moves.configparser import ConfigParser
 from six.moves.configparser import DuplicateSectionError
+from six.moves.configparser import NoOptionError
 from six.moves.configparser import NoSectionError
 from d_rats.ui.main_common import MainWindowElement, MainWindowTab
 from d_rats.ui.main_common import prompt_for_station, \
@@ -134,7 +135,7 @@ class MessageFolderInfo():
 
         try:
             return self._config.get(filename, prop)
-        except NoSectionError:
+        except (NoOptionError, NoSectionError):
             return _("Unknown")
 
     def get_msg_subject(self, filename):


### PR DESCRIPTION
Messages to internet gateways were deadlocked until at
least one station was heard.

d_rats/mailsrv.py:
  Remove immortality from the POP3 server

d_rats/mainapp.py
  Start of emailgw import refactor.
  In _refresh_mail_threads method use copy of dict,
  and clean up starting SMTP and POP3 servers.
  Pass parameters to MessageRouter class to remove
  hacked import, first pass for a cleanup refactoring.

d_rats/msgrouting.py:
  Improved Docstrings
  Remove python2 compatibility code.
  MsgRouter class now gets mainapp, validate_incoming
  passed to it.
  In _run_one_method, do not wait for a station to be
  heard by d-rats before sending messages to
  internet based locations.

d_rats/ui/main_messages.py:
  Fix an exception handler issue.