### PR TITLE
fix(w2lk): bytes to string conversions

### DIFF
--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -869,6 +869,7 @@ class WinLinkTelnet(WinLinkCMS):
             rem = 6
             todo = 3
             cresp_str = ""
+            zero = ord('0')
             while rem > 0:
                 octet = random.randint(0, 255)
 
@@ -876,7 +877,7 @@ class WinLinkTelnet(WinLinkCMS):
                     cresp_str += chr(random.randint(33, 126))
                 else:
                     todo -= 1
-                    cresp_str += passwd[int(chall[todo])]
+                    cresp_str += passwd[chall[todo] - zero]
                 rem -= 1
 
             self._send(cresp_str.encode('utf-8', 'replace'))

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -496,7 +496,7 @@ class WinLinkMessage:
 
         # Checksum, mod 256, two's complement
         checksum = (~checksum & 0xFF) + 1
-        sock.send(struct.pack("<BB", FBB_BLOCK_EOF, sum))
+        sock.send(struct.pack("<BB", FBB_BLOCK_EOF, checksum))
 
     def get_content(self):
         '''

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -831,7 +831,7 @@ class WinLinkTelnet(WinLinkCMS):
         if not resp.startswith(b"Callsign :"):
             raise Wl2kTelnetNoLogin("Conversation error (never saw login)")
 
-        self._send(self._callsign)
+        self._send(self._callsign.encode('utf-8', 'replace'))
         resp = self._recv()
         if not resp.startswith(b"Password :"):
             raise Wl2kTelnetNoPassword("Conversation error (never saw password)")


### PR DESCRIPTION
d_rats/wl2k.py:
  Improve Docstrings.
  Set explicit endian for struct pack, especially since w2lk uses
  little-endian instead of network-endian.
  In _run_outgoing() method, message header must be parsed as bytes and
  parsed data must be converted to strings.