### PR TITLE
fix(gps) Fix invalid names

### DIFF
--- a/d_rats/gps.py
+++ b/d_rats/gps.py
@@ -254,8 +254,7 @@ def value_with_units(value):
     return "%.2f %s" % (value * scale, units)
 
 
-# pylint: disable=invalid-name
-def NMEA_checksum(string):
+def nmea_checksum(string):
     '''
     NMEA Checksum.
 
@@ -271,8 +270,7 @@ def NMEA_checksum(string):
     return "*%02x" % checksum
 
 
-# pylint: invalid-name
-def GPSA_checksum(string):
+def gpsa_checksum(string):
     '''
     GPSA Checksum.
 
@@ -297,8 +295,7 @@ def GPSA_checksum(string):
     return calc(string)
 
 
-# pylint: disable=invalid-name
-def DPRS_checksum(callsign, msg):
+def dprs_checksum(callsign, msg):
     '''
     DPRS Checksum.
 
@@ -549,8 +546,7 @@ class GPSPosition():
         self.date = datetime.datetime.now()
         self.speed = None
         self.direction = None
-        # pylint: disable=invalid-name
-        self.APRSIcon = None
+        self.aprs_icon = None
         self._original_comment = ""
         self.latitude = None
         self.longitude = None
@@ -576,7 +572,7 @@ class GPSPosition():
         astidx = self.comment.rindex("*")
         checksum = self.comment[astidx:]
 
-        calc_checksum = DPRS_checksum(self.station, self.comment[:astidx])
+        calc_checksum = dprs_checksum(self.station, self.comment[:astidx])
 
         if int(calc_checksum[1:], 16) != int(checksum[1:], 16):
             self.logger.info("_parse_dprs_comment: Failed to parse "
@@ -593,7 +589,7 @@ class GPSPosition():
 
             raise GpsDprsChecksumError("DPRS checksum failed")
 
-        self.APRSIcon = dprs_to_aprs(symbol)
+        self.aprs_icon = dprs_to_aprs(symbol)
         self.comment = self.comment[4:astidx].strip()
 
     def __iadd__(self, update):
@@ -624,8 +620,8 @@ class GPSPosition():
             # pylint: disable=protected-access
             self._original_comment = update._original_comment
 
-        if update.APRSIcon:
-            self.APRSIcon = update.APRSIcon
+        if update.aprs_icon:
+            self.aprs_icon = update.aprs_icon
 
         return self
 
@@ -719,8 +715,7 @@ class GPSPosition():
 
         return sta
 
-    # pylint: disable=invalid-name
-    def to_NMEA_GGA(self, _ssid=" "):
+    def to_nmea_gga(self, _ssid=" "):
         '''
         To NMEA GGA.
 
@@ -750,7 +745,7 @@ class GPSPosition():
             com = self.comment
 
         return "$%s%s\r\n%-8.8s,%-20.20s\r\n" % (data,
-                                                 NMEA_checksum(data),
+                                                 nmea_checksum(data),
                                                  sta,
                                                  com)
 
@@ -789,12 +784,11 @@ class GPSPosition():
         sta = self.station_format()
 
         return "$%s%s\r\n%-8.8s,%-20.20s\r\n" % (data,
-                                                 NMEA_checksum(data),
+                                                 nmea_checksum(data),
                                                  sta,
                                                  self.comment)
 
-    # pylint: disable=invalid-name
-    def to_APRS(self, dest="APRATS", symtab="/", symbol=">"):
+    def to_aprs(self, dest="APRATS", symtab="/", symbol=">"):
         '''
         To APRS.
 
@@ -857,7 +851,7 @@ class GPSPosition():
 
         sta_str += "\r"
 
-        return "$$CRC%04X,%s\n" % (GPSA_checksum(sta_str), sta_str)
+        return "$$CRC%04X,%s\n" % (gpsa_checksum(sta_str), sta_str)
 
     def set_station(self, station, comment="D-RATS"):
         '''
@@ -992,7 +986,7 @@ class NMEAGPSPosition(GPSPosition):
         segment = string[1:idx]
 
         csum = csum.upper()
-        calc_csum = NMEA_checksum(segment).upper()
+        calc_csum = nmea_checksum(segment).upper()
 
         if csum != calc_csum:
             self.logger.info("_test_checksum: Failed checksum: %s != %s",
@@ -1157,7 +1151,7 @@ class APRSGPSPosition(GPSPosition):
             return
 
         crc = match.group(1)
-        calc_crc = "%04X" % GPSA_checksum(match.group(2))
+        calc_crc = "%04X" % gpsa_checksum(match.group(2))
 
         if crc != calc_crc:
             self.logger.info("_parse_GPSA: APRS CRC mismatch: %s != %s (%s)",
@@ -1208,7 +1202,7 @@ class APRSGPSPosition(GPSPosition):
         self.longitude = nmea2deg(float(match.group(7)), match.group(8))
         self.comment = match.group(10).strip()
         self._original_comment = self.comment
-        self.APRSIcon = match.group(6) + match.group(9)
+        self.aprs_icon = match.group(6) + match.group(9)
 
         if len(match.groups()) == 11 and match.group(11):
             _, alt = match.group(11).split("=")

--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -1135,15 +1135,15 @@ class MainApp(Gtk.Application):
 
         try:
             comment = self.config.get("settings", "default_gps_comment")
-            fix.APRSIcon = gps.dprs_to_aprs(comment)
+            fix.aprs_icon = gps.dprs_to_aprs(comment)
         # pylint: disable=broad-except
         except Exception:
             self.logger.info("_refresh_location broad-except", exc_info=True)
             log_exception()
-            fix.APRSIcon = "\\?"
+            fix.aprs_icon = "\\?"
             # broad/bare exceptions make debugging harder
             raise
-        self.__map_point.set_icon_from_aprs_sym(fix.APRSIcon)
+        self.__map_point.set_icon_from_aprs_sym(fix.aprs_icon)
 
         self.stations_overlay.add_point(self.__map_point)
         self.map.update_gps_status(self.gps.status_string())
@@ -1510,12 +1510,12 @@ class MainApp(Gtk.Application):
                                        fix.longitude,
                                        fix.altitude,
                                        fix.comment)
-        if fix.APRSIcon is None:
+        if fix.aprs_icon is None:
             point.set_icon_from_aprs_sym('\\?')
             self.logger.info(
-                "__incoming_gps_fix: APRSIcon missing - forced to: \\? ")
+                "__incoming_gps_fix: aprs_icon missing - forced to: \\? ")
         else:
-            point.set_icon_from_aprs_sym(fix.APRSIcon)
+            point.set_icon_from_aprs_sym(fix.aprs_icon)
 
         source.add_point(point)
         source.save()

--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -832,7 +832,7 @@ class MapWindow(Gtk.ApplicationWindow):
                 for port in self.emit("get-station-list").keys():
                     self.emit("user-send-chat",
                               "CQCQCQ", port,
-                              fix.to_NMEA_GGA(), True)
+                              fix.to_nmea_gga(), True)
 
                 break
             except AttributeError:

--- a/d_rats/qst.py
+++ b/d_rats/qst.py
@@ -293,7 +293,7 @@ class QSTGPS(QSTText):
         fix.set_station(fix.station, self.text[:20])
 
         if fix.valid:
-            return fix.to_NMEA_GGA()
+            return fix.to_nmea_gga()
         return None
 
 
@@ -321,7 +321,7 @@ class QSTGPSA(QSTGPS):
             self.text = self.text[1:]
 
         if fix.valid:
-            return fix.to_APRS(symtab=self.config.get("settings", "aprssymtab"),
+            return fix.to_aprs(symtab=self.config.get("settings", "aprssymtab"),
                                symbol=self.config.get("settings", "aprssymbol"))
         return None
 
@@ -368,10 +368,10 @@ class QSTWX(QSTGPS):
             fix.set_station(fix.station, wx_line[:200])
 
         if fix.valid:
-            return fix.to_APRS(symtab="/",
+            return fix.to_aprs(symtab="/",
                                symbol="_")
 #       WX symbol will be used for WXGPS-A.
-#       return fix.to_APRS(symtab=self.config.get("settings", "aprssymtab"),
+#       return fix.to_aprs(symtab=self.config.get("settings", "aprssymtab"),
 #                          symbol=self.config.get("settings", "aprssymbol")
         self.logger.info("do_qst: "
                          "GPS postition is not valid, so not sent")

--- a/d_rats/sessions/rpc.py
+++ b/d_rats/sessions/rpc.py
@@ -762,13 +762,13 @@ class RPCActionSet(GObject.GObject):
         if rqcall in (mycall, "."):
             rqcall = None
         try:
-            #obtaining current position from config or local gps
+            # obtaining current position from config or local gps
             fix = self.emit("get-current-position", rqcall)
-            #result = fix.to_NMEA_GGA()
+            # result = fix.to_nmea_gga()
             result["rc"] = "True"
             symtab = self.__config.get("settings", "aprssymtab")
             symbol = self.__config.get("settings", "aprssymbol")
-            result["msg"] = fix.to_APRS(symtab=symtab, symbol=symbol)
+            result["msg"] = fix.to_aprs(symtab=symtab, symbol=symbol)
 
         # pylint: disable=broad-except
         except Exception:
@@ -786,7 +786,7 @@ class RPCActionSet(GObject.GObject):
             self.logger.info("RPC_pos_report: port is : %s", self.__port)
             self.logger.info("RPC_pos_report: fix is: %s", fix)
             self.logger.info("RPC_pos_report: fix in NMEA GGA is: %s",
-                             fix.to_NMEA_GGA())
+                             fix.to_nmea_gga())
             self.logger.info("RPC_pos_report: fix in APRS is: %s", result)
 
             self.emit("user-send-chat",

--- a/docs/source/d_rats.rst
+++ b/docs/source/d_rats.rst
@@ -285,14 +285,6 @@ d\_rats.station\_status module
     :undoc-members:
     :show-inheritance:
 
-d\_rats.subst module
---------------------
-
-.. automodule:: d_rats.subst
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 d\_rats.transport module
 ------------------------
 


### PR DESCRIPTION
Fix names to match current python conventions

d_rats/gps.py:
  rename methods to current python conventions.

d_rats/mainapp.py:
d_rats/map/mapwindow.py:
d_rats/qst.py:
d_rats/sessions/rpc.py:
  rename methods from gps.py to new names.

docs/source/d_rats.rst:
  remove d_rats.subst from document list