### PR TITLE
fix(doc): Documentation fixes

### DIFF
--- a/d_rats/dplatform.py
+++ b/d_rats/dplatform.py
@@ -295,12 +295,13 @@ class Platform():
         :param command: Command to run and wait for
         :type command: str
         :returns: Command standard output in second member of tuple
-        :rtype: tuple
+        :rtype: tuple[int, str]
         '''
         pipe = subprocess.Popen(command, stdout=subprocess.PIPE)
         data = pipe.stdout.read()
+        data_str = data.decode('utf-8', 'replace')
 
-        return 0, data
+        return 0, data_str
 
     def retrieve_url(self, url):
         '''
@@ -471,6 +472,8 @@ class UnixPlatform(Platform):
 
         :param command: Command to run.
         :type command: str
+        :returns: Command status and output
+        :rtype: tuple[int, str]
         '''
         return subprocess.getstatusoutput(command)
 
@@ -567,7 +570,7 @@ class MacOSXPlatform(UnixPlatform):
         List Serial Ports.
 
         :returns: serial port names
-        :rtype: list of str
+        :rtype: list[str]
         '''
         keyspan = glob.glob("/dev/cu.KeySerial*")
         prolific = glob.glob("/dev/tty.usbserial*")
@@ -663,7 +666,7 @@ class Win32Platform(Platform):
         List Serial Ports.
 
         :returns: List of serial ports
-        :rtype: list of str
+        :rtype: list[str]
         '''
         # pylint: disable=import-error
         try:

--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -322,7 +322,7 @@ class MapWindow(Gtk.ApplicationWindow):
         Get Map Sources.
 
         :returns: Map sources
-        :rtype: list of :class:`MapFileSource`
+        :rtype: list[:class:`MapFileSource`]
         '''
         return self.map_sources
 
@@ -331,7 +331,7 @@ class MapWindow(Gtk.ApplicationWindow):
         Get Visible Bounds.
 
         :returns: tuple with bounds
-        :rtype: tuple
+        :rtype: tuple[int, int, int, int]
         '''
         hadj = self.scrollw.get_hadjustment()
         vadj = self.scrollw.get_vadjustment()
@@ -758,7 +758,7 @@ class MapWindow(Gtk.ApplicationWindow):
         Printable Map Handler.
 
         :param bounds: Bounds to save
-        :type bounds: tuple of 4 elements
+        :type bounds: tuple[int, int, int, int]
         :returns: False to prevent timer retriggering
         :rtype: bool
         '''
@@ -862,8 +862,8 @@ class MapWindow(Gtk.ApplicationWindow):
         :type point: :class:`MapPoint`
         :param group: Optional group
         :type group: str
-        :returns: Tuple of (point, group) or (None, None)
-        :rtype: tuple of (:class:`MapPoint', str)
+        :returns: point and group when a marker is set.
+        :rtype: tuple [:class:`MapPoint`, str]
         '''
         dialog = Map.MarkerEditDialog()
 
@@ -898,7 +898,7 @@ class MapWindow(Gtk.ApplicationWindow):
         Save Map.
 
         :param bounds: Bounds to save, Default None
-        :type bounds: tuple of 4 elements
+        :type bounds: tuple[int, int, int, int]
         '''
         platform = dplatform.get_platform()
         fname = platform.gui_save_file(default_name="map_%s.png" % \
@@ -918,7 +918,7 @@ class MapWindow(Gtk.ApplicationWindow):
         :param fname: Filename to save to
         :type fname: str
         :param bounds: Bounds to save
-        :type bounds: tuple of 4 elements
+        :type bounds: tuple[int, int, int, int]
         :returns: False to prevent timer retriggering
         :rtype: bool
         '''

--- a/d_rats/pluginsrv.py
+++ b/d_rats/pluginsrv.py
@@ -266,7 +266,7 @@ class DRatsPluginProxy(GObject.GObject):
         :param timeout: Time out to wait
         :type timeout: float
         :param src_station: Optional Station to wait for message from
-        :type src_station:str
+        :type src_station: str
         :returns: Source station and chat text
         :rtype: tuple[str, str]
         '''

--- a/d_rats/wu.py
+++ b/d_rats/wu.py
@@ -108,7 +108,7 @@ class WUObservation():
 
         :param uri: URI to lookup
         :type uri: str
-        :'''
+        '''
         file_name, _something = urllib.request.urlretrieve(uri)
         doc = etree.parse(file_name)
         os.remove(file_name)

--- a/docs/source/d_rats.rst
+++ b/docs/source/d_rats.rst
@@ -213,14 +213,6 @@ d\_rats.msgrouting module
     :undoc-members:
     :show-inheritance:
 
-d\_rats.platform module
------------------------
-
-.. automodule:: d_rats.platform
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 d\_rats.pluginsrv module
 ------------------------
 


### PR DESCRIPTION
Fix issues with document generation.

d_rats/dplatform.py:
  Improve Docstrings.
  The run_sync method should return str, not bytes to be
  consistent on all platforms.

d_rats/map/mapwindow.py
  Docstring fixes and improvements.

d_rats/pluginsrv.py:
d_rats/wu.py:
  Docstring fix.

docs/source/d_rats.rst:
  Remove entry for platform module.