### PR TITLE
fix(rpc): Code cleanup

### DIFF
--- a/d_rats/sessionmgr.py
+++ b/d_rats/sessionmgr.py
@@ -23,16 +23,10 @@ from __future__ import print_function
 import logging
 import time
 import threading
-# import os
-# import struct
-# import socket
-from six.moves import range # type: ignore
 
 from . import transport
-# from .ddt2 import DDT2EncodedFrame
 
 from .sessions import base, control, stateful, stateless
-# from .sessions import file, form, sock, sniff
 
 
 # pylint: disable=too-many-instance-attributes
@@ -224,7 +218,7 @@ class SessionManager():
             session.handler(frame)
         else:
             session.inq.enqueue(frame)
-            session.notify()
+            session.notify_event()
 
         self.logger.info("incoming: Received block %i:%i for session `%s'",
                          frame.seq, frame.type, session.name)
@@ -395,11 +389,8 @@ class SessionManager():
         '''
         try:
             del self.sessions[ident]
-        # pylint: disable=broad-except
-        except Exception:
-            self.logger.info("end_session:"
-                             "Unable to deregister session broad-exception",
-                             exc_info=True)
+        except KeyError:
+            self.logger.info("end_session: Unable to deregister session")
 
     def get_session(self, rid=None, rst=None, lid=None):
         '''

--- a/d_rats/sessions/base.py
+++ b/d_rats/sessions/base.py
@@ -2,7 +2,7 @@
 '''Base Session.'''
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
-# Python3 update Copyright 2021 John Malmberg <wb8tyw@qsl.net>
+# Python3 update Copyright 2021-2022 John Malmberg <wb8tyw@qsl.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,9 +46,7 @@ class SessionClosedError(BaseSessionException):
     '''Session Closed Error.'''
 
 
-# Need to inherit from object for python2 compatibility
-# pylint: disable=useless-object-inheritance
-class Session(object):
+class Session():
     '''
     Session.
 
@@ -111,8 +109,8 @@ class Session(object):
         if self._sm:
             self._sm.stop_session(self)
 
-    def notify(self):
-        '''Notify.'''
+    def notify_event(self):
+        '''Notify Event Change.'''
 
     def read(self):
         '''Read.'''
@@ -139,7 +137,7 @@ class Session(object):
 
         self.state = state
         self.state_event.set()
-        self.notify()
+        self.notify_event()
         return True
 
     def get_state(self):

--- a/d_rats/sessions/stateful.py
+++ b/d_rats/sessions/stateful.py
@@ -2,7 +2,7 @@
 '''Stateful.'''
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
-# Python3 update Copyright 2021 John Malmberg <wb8tyw@qsl.net>
+# Python3 update Copyright 2021-2022 John Malmberg <wb8tyw@qsl.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -99,7 +99,8 @@ class StatefulSession(base.Session):
         self.thread.setDaemon(True)
         self.thread.start()
 
-    def notify(self):
+    def notify_event(self):
+        '''Notify Event.'''
         self.event.set()
 
     def close(self, force=False):
@@ -109,7 +110,7 @@ class StatefulSession(base.Session):
         self.logger.info("close: Got close request, joining thread...")
         self._closed = True
         self.enabled = False
-        self.notify()
+        self.notify_event()
 
         # this should just be "if self.outstanding:"
         # Free up any block listeners


### PR DESCRIPTION
d_rats/sessionmgr.py:
  Remove python2 compatibility code.
  Fix name conflict for RPC notify_event().
  Remove a broad exception

d_rats/sessions/base.py:
  Remove python2 compatibility code.
  The notify method name conflicts with child class inherited GObject
  notify method name in rpc.py, change name to notify_event.

d_rats/sessions/rpc.py:
  Remove python2 compatibility code.
  The notify method name conflicts with inherited GObject
  notify method name, change name to notify_event.
  Improve DocStrings
  Fix invalid method names.

d_rats/sessions/stateful.py:
  The notify method name conflicts with inherited GObject
  notify method name in rpc.py, change name to notify_event.