### PR TITLE
fix(pluginsrv) pluginsrv module

### DIFF
--- a/d_rats/sessions/rpc.py
+++ b/d_rats/sessions/rpc.py
@@ -158,7 +158,7 @@ class RPCJob(GObject.GObject):
     '''
     RPC Job Parent Class.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -253,7 +253,7 @@ class RPCFileListJob(RPCJob):
     '''
     RPC File List Job.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -295,7 +295,7 @@ class RPCFormListJob(RPCJob):
     '''
     RPC Form List Job.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -326,7 +326,7 @@ class RPCFormListJob(RPCJob):
 class RPCPullFileJob(RPCJob):
     '''RPC Pull File Job.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -366,7 +366,7 @@ class RPCDeleteFileJob(RPCJob):
     '''
     RPC Delete File Job.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -424,7 +424,7 @@ class RPCPullFormJob(RPCJob):
     '''
     RPC Pull Form Job.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -464,7 +464,7 @@ class RPCPositionReport(RPCJob):
     '''
     RPC Position Report.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -504,7 +504,7 @@ class RPCGetVersion(RPCJob):
     '''
     RPC Get Version.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str
@@ -526,7 +526,7 @@ class RPCCheckMail(RPCJob):
     '''
     RPC Check Mail.
 
-    :param dest: Destintion of job
+    :param dest: Destination of job
     :type dest: str
     :param desc: Description of job
     :type desc: str

--- a/d_rats/utils.py
+++ b/d_rats/utils.py
@@ -502,19 +502,20 @@ def set_entry_hint(entry, hint, default_focused=False):
         focus(entry, None, "out")
 
 
-def port_for_station(ports, station):
+def port_for_stationid(ports, stationid):
     '''
-    Port for station
+    Port for a Station Identification.
 
-    :param ports: Radio port to look for a station in
+    :param ports: Radio port to look for a station identification in
     :type ports: dict
-    :param station: Station callsign to lookup
-    :type station: str
+    :param stationid: Station identification to lookup
+    :type stationid: str
     :returns: Port if found or none.
     '''
     for port, stations in ports.copy().items():
-        if station in stations:
-            return port
+        for station in stations:
+            if stationid == str(station):
+                return port
     return None
 
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -7,3 +7,4 @@ D-Rats
    d-rats
    d-rats_repeater
    d_rats
+   plugin_test

--- a/docs/source/plugin_test.rst
+++ b/docs/source/plugin_test.rst
@@ -1,0 +1,7 @@
+plugin_test module
+==================
+
+.. automodule:: plugin_test
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/plugin_test.py
+++ b/plugin_test.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python
+# pylint: disable=invalid-name
+'''
+plugin_test.
+
+This is a test and demonstration of using the d-rats plugin feature.
+'''
+
+import argparse
+import gettext
+import logging
+import time
+
+from xmlrpc.client import Fault
+from xmlrpc.client import ServerProxy
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the classes and methods in this module.
+if not '_' in locals():
+    _ = gettext.gettext
+
+
+# pylint wants at least 2 public methods
+# pylint: disable=too-few-public-methods
+class PluginProxy:
+    '''
+    Plugin Proxy Client.
+
+    :param server: D-rats plugin server address
+    :type server: str
+    :param port: D-Rats plugin server port
+    :type port: int
+    '''
+
+    def __init__(self, server, port):
+        pluginsrv = "http://%s:%i" % (server, port)
+        self.server = ServerProxy(pluginsrv)
+
+    def wait_for_result(self, ident, count=10, delay=5):
+        '''
+        Wait for result.
+
+        :param ident: identification of RPC job
+        :type ident: int
+        :param count: Number of times to poll for result, default 10
+        :type count int
+        :param delay: Delay time in seconds
+        :type delay: float
+        :returns: Result of call
+        :rtype: dict
+        '''
+        while count > 0:
+            count -= 1
+            time.sleep(delay)
+            result = self.server.get_result(ident)
+            if result:
+                break
+        return result
+
+
+def main():
+    '''Plugin test Main module.'''
+
+    gettext.install("D-RATS")
+    lang = gettext.translation("D-RATS",
+                               localedir="locale",
+                               fallback=True)
+    lang.install()
+    # pylint: disable=global-statement
+    global _
+    _ = lang.gettext
+
+
+    # pylint: disable=too-few-public-methods
+    class LoglevelAction(argparse.Action):
+        '''
+        Custom Log Level action.
+
+        This allows entering a log level command line argument
+        as either a known log level name or a number.
+        '''
+
+        def __init__(self, option_strings, dest, nargs=None, **kwargs):
+            if nargs is not None:
+                raise ValueError("nargs is not allowed")
+            argparse.Action.__init__(self, option_strings, dest, **kwargs)
+
+        def __call__(self, parser, namespace, values, option_strings=None):
+            level = values.upper()
+            level_name = logging.getLevelName(level)
+            # Contrary to documentation, the above returns for me
+            # an int if given a name or number of a known named level and
+            # str if given a number for a level with out a name.
+            if isinstance(level_name, int):
+                level_name = level
+            elif level_name.startswith('Level '):
+                level_name = int(level)
+            setattr(namespace, self.dest, level_name)
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=_('PLUGIN_TEST'))
+
+    # While loglevel actually returns an int, it needs to be set to the
+    # default type of str for the action routine to handle both named and
+    # numbered levels.
+    parser.add_argument('--loglevel',
+                        action=LoglevelAction,
+                        default='INFO',
+                        help=_('LOGLEVEL TO TEST WITH'))
+
+    # Future option, right now d-rats is only listening on localhost
+    parser.add_argument("-s", "--server",
+                        default='localhost',
+                        help="D-rats CLIENT PLUGIN SERVER NAME")
+
+    # Future option, right now d-rats is only listening on port 9100
+    parser.add_argument("-p", "--port",
+                        default=9100,
+                        help="D-rats CLIENT PLUGIN SERVER PORT")
+
+    parser.add_argument("--stationid",
+                        default='NOCALL',
+                        help="Station ID to use for test")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
+                        datefmt="%m/%d/%Y %H:%M:%S",
+                        level=args.loglevel)
+
+    logger = logging.getLogger("Plugin_Test")
+
+    proxy = PluginProxy(args.server, args.port)
+
+    ports = proxy.server.list_ports()
+    logger.info("ports %s", ports)
+
+    try:
+        rpc_job = proxy.server.submit_rpcjob(args.stationid, 'RPCGetVersion')
+        logger.info("rpc_job %i", rpc_job)
+
+        result = proxy.wait_for_result(rpc_job)
+
+        for key, value in result.items():
+            print("key %s value %s" % (key, value))
+    except Fault as err:
+        logger.info("Plugin call failed: %s", err)
+
+
+if __name__ == "__main__":
+    main()
+
+# Things to test eventually.
+# "send_chat"
+# "wait_for_chat"
+# "list_ports" (x)
+# "send_file"
+# "submit_rpcjob" (1 of 8)
+# "get_result"
+#   'RPCFileListJob(destination, description)
+#   'RPCFormListJob',
+#   'RPCPullFileJob',
+#   'RPCDeleteFileJob',
+#   'RPCPullFormJob',
+#   'RPCPositionReport',
+#   'RPCGetVersion', (x)
+#   'RPCCheckMail'


### PR DESCRIPTION
Starting to standardize on using variable name of stationid for
a callsign with a dash suffix to avoid confusion.

d_rats/pluginsrv.py:
  Change to use stationid.
  Fix lookup of RPC modules.

d_rats/sessions/rpc.py:
  Fix spelling error in Docstrings.

d_rats/utils.py:
  Renamed port_for_station to port_for_stationid.

docs/source/modules.rst
  Add plugin_test module

docs/source/plugin_test.rst: New Module.

plugin_test.py: New module.
  Start of a module to fully test the pluginsrv module.