### PR TITLE
fix(threads): Deprecated thread methods

### DIFF
--- a/d_rats/emailgw.py
+++ b/d_rats/emailgw.py
@@ -187,7 +187,7 @@ class MailThread(threading.Thread, GObject.GObject):
         threading.Thread.__init__(self)
         GObject.GObject.__init__(self)
         self.logger = logging.getLogger("MailThread")
-        self.setDaemon(True)
+        self.daemon = True
 
         self.username = user
         self.password = pasw

--- a/d_rats/mailsrv.py
+++ b/d_rats/mailsrv.py
@@ -72,7 +72,7 @@ class TCPServerThread(threading.Thread):
         self.__server = server(server_address, RequestHandlerClass)
         self.__server.set_config(config)
         threading.Thread.__init__(self)
-        self.setDaemon(True)
+        self.daemon = True
 
     def run(self):
         '''Run Server.'''
@@ -517,7 +517,7 @@ class DratsPOP3ServerThread(TCPServerThread):
         self.logger.info("[POP3] Starting server on port %i", port)
         TCPServerThread.__init__(self, config, DratsPOP3Server,
                                  ("0.0.0.0", port), DratsPOP3Handler)
-        self.setDaemon(True)
+        self.daemon = True
 
 
 class DratsSMTPServer(smtpd.SMTPServer):
@@ -586,7 +586,7 @@ class DratsSMTPServerThread(threading.Thread):
     def __init__(self, config):
         self.logger = logging.getLogger("DratsSMTPServerThread")
         threading.Thread.__init__(self)
-        self.setDaemon(True)
+        self.daemon = True
         self.__config = config
         self.__server = None
 

--- a/d_rats/map/maptile.py
+++ b/d_rats/map/maptile.py
@@ -602,7 +602,7 @@ class MapTile():
         '''
         new_args = (widget,)
         tfetch = threading.Thread(target=self._thread, args=new_args)
-        tfetch.setDaemon(True)
+        tfetch.daemon = True
         tfetch.start()
 
     def local_path(self):

--- a/d_rats/map_sources.py
+++ b/d_rats/map_sources.py
@@ -231,12 +231,12 @@ class MapPointThreaded(MapPoint):
         self.__ts = 0
 
     def __start_thread(self):
-        if self.__thread and self.__thread.isAlive():
+        if self.__thread and self.__thread.is_alive():
             self.logger.info("Threaded Point: Still waiting on a thread")
             return
 
         self.__thread = threading.Thread(target=self.__thread_fn)
-        self.__thread.setDaemon(True)
+        self.__thread.daemon = True
         self.__thread.start()
 
     def _retr_hook(self, method, attribute):

--- a/d_rats/pluginsrv.py
+++ b/d_rats/pluginsrv.py
@@ -326,7 +326,7 @@ class DRatsPluginServer(SimpleXMLRPCServer):
     def serve_background(self):
         '''Serve Background'''
         self.__thread = threading.Thread(target=self.serve_forever)
-        self.__thread.setDaemon(True)
+        self.__thread.daemon = True
         self.__thread.start()
         self.logger.info("Started serve_forever() thread")
 

--- a/d_rats/session_coordinator.py
+++ b/d_rats/session_coordinator.py
@@ -82,7 +82,7 @@ class SessionThread():
         self.arg = data
 
         self.thread = threading.Thread(target=self.worker, args=(data,))
-        self.thread.setDaemon(True)
+        self.thread.daemon = True
         self.thread.start()
 
     def stop(self):
@@ -763,7 +763,7 @@ class SessionCoordinator(GObject.GObject):
                     "cls"       : xfer,
                     "blocksize" : block_size,
                     "outlimit"  : outlimit})
-        file_thread.setDaemon(True)
+        file_thread.daemon = True
         file_thread.start()
         self.logger.info("send_file: Started Session")
 
@@ -788,7 +788,7 @@ class SessionCoordinator(GObject.GObject):
             kwargs={"name" : name,
                     "dest" : dest,
                     "cls"  : xfer})
-        form_thread.setDaemon(True)
+        form_thread.daemon = True
         form_thread.start()
         self.logger.info("Started form session")
 

--- a/d_rats/sessionmgr.py
+++ b/d_rats/sessionmgr.py
@@ -104,19 +104,19 @@ class SessionManager():
         '''
         self._stations_heard[station] = time.time()
 
-    def fire_session_cb(self, session, reason):
+    def fire_session_cb(self, ident, reason):
         '''
         Fire Session call back.
 
-        :param session: Session for call back
-        :type session: :class:`Session`
+        :param ident: Session identification number for call back
+        :type ident: int
         :param reason: Reason for callback
         :type reason: str
         '''
         for function, data in self.session_cb.copy().items():
             try:
                 # function is SessionCoordinator method?
-                function(data, reason, session)
+                function(data, reason, ident)
             # pylint: disable=broad-except
             except Exception:
                 self.logger.info("fire_session_cb: broad-exception",
@@ -276,7 +276,7 @@ class SessionManager():
 
         :param session: new session
         :type session: :class:`sessions.base.Session`
-        :param dest: Destination for session
+        :param dest: Destination station for session
         :type dest: str
         :param reason: Reason for session
         :type reason: str
@@ -472,7 +472,7 @@ def main():
                 logger.info("Receiving file")
                 thread = threading.Thread(target=session.recv_file,
                                           args=("/tmp",))
-                thread.setDaemon(True)
+                thread.daemon = True
                 thread.start()
                 logger.info("Done")
 

--- a/d_rats/sessions/rpc.py
+++ b/d_rats/sessions/rpc.py
@@ -711,7 +711,7 @@ class RPCSession(GObject.GObject, stateless.StatelessSession):
 
     def __worker(self):
         for ident, (time_stamp, att, job) in self.__jobs.copy().items():
-            if job.frame and not job.frame.sent_event.isSet():
+            if job.frame and not job.frame.sent_event.is_set():
                 # Reset timer until the block is sent
                 self.__jobs[ident] = (time.time(), att, job)
             elif (time.time() - time_stamp) > self.__t_retry:

--- a/d_rats/sessions/sock.py
+++ b/d_rats/sessions/sock.py
@@ -83,7 +83,7 @@ class SocketListener():
         self.lsock = None
         self.dsock = None
         self.thread = Thread(target=self.listener)
-        self.thread.setDaemon(True)
+        self.thread.daemon = True
         self.thread.start()
 
     def stop(self):

--- a/d_rats/sessions/stateful.py
+++ b/d_rats/sessions/stateful.py
@@ -96,7 +96,7 @@ class StatefulSession(base.Session):
         self._closed = False
         self.hexdump = False
         self.thread = threading.Thread(target=self.worker)
-        self.thread.setDaemon(True)
+        self.thread.daemon = True
         self.thread.start()
 
     def notify_event(self):
@@ -291,7 +291,7 @@ class StatefulSession(base.Session):
 
         last_block = None
         for b_block in self.outstanding:
-            if b_block.sent_event.isSet():
+            if b_block.sent_event.is_set():
                 self.stats["retries"] += 1
                 b_block.sent_event.clear()
 
@@ -493,7 +493,7 @@ class StatefulSession(base.Session):
             else:
                 self.logger.info("worker: Deep sleep")
                 self.event.wait(self.IDLE_TIMEOUT)
-                if not self.event.isSet():
+                if not self.event.is_set():
                     self.logger.info("worker: Session timed out!")
                     self.set_state(base.ST_CLSD)
                     self.enabled = False
@@ -620,11 +620,11 @@ class StatefulSession(base.Session):
             self.logger.info("write: Waiting for block %i ACK to be received",
                              block.seq)
             block.sent_event.wait()
-            if block.sent_event.isSet():
+            if block.sent_event.is_set():
                 self.logger.info("write: Block %i is sent, waiting for ack",
                                  block.seq)
                 block.ackd_event.wait(timeout)
-                if block.ackd_event.isSet() and block.sent_event.isSet():
+                if block.ackd_event.is_set() and block.sent_event.is_set():
                     self.logger.info("write: %i ACK received", block.seq)
                 else:
                     self.logger.info("write: %i No ACK received "

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -954,7 +954,7 @@ class WinLinkThread(threading.Thread, GObject.GObject):
         threading.Thread.__init__(self)
         self.logger = logging.getLogger("WinLinkThread")
 
-        self.setDaemon(True)
+        self.daemon = True
         GObject.GObject.__init__(self)
 
         if not callssid:


### PR DESCRIPTION
Fix deprecated thread methods for support of python > 3.8

Each global logger should have its own name in upper case.

d_rats/emailgw.py:
d_rats/map_sources.py:
d_rats/mailsrv.py:
d_rats/pluginsrv.py:
d_rats/session_coordinator.py:
d_rats/sessionmgr.py:
d_rats/wl2k.py:
d_rats/map/maptile.py:
d_rats/sessions/rpc.py:
d_rats/sessions/sock.py:
d_rats/sessions/stateful.py:
  Threading fix.

d_rats/gps.py:
  Fix global logger.
  Fix broad-exceptions.
  Threading fix.

d_rats/msgrouting.py:
  Fix global logger.
  Threading fix.