### PR TITLE
fix(emailgw): set log level debug

### DIFF
--- a/d_rats/emailgw.py
+++ b/d_rats/emailgw.py
@@ -210,8 +210,8 @@ class MailThread(threading.Thread, GObject.GObject):
         :param message: Message to log
         :type message: :class:`EmailMessage`
         '''
-        self.logger.info("[MAIL %s@%s] %s",
-                         self.username, self.server, message)
+        self.logger.debug("[MAIL %s@%s] %s",
+                          self.username, self.server, message)
 
     def create_form_from_mail(self, mail):
         '''


### PR DESCRIPTION
The periodic polling for the emailgw is just flooding th console log.
Change to debug for now.

d_rats/emailgw.py:
  Move the log level for emailgw to debug