### PR TITLE
fix(application): Gtk.ApplicationWindow

### DIFF
--- a/d_rats/mainwindow.py
+++ b/d_rats/mainwindow.py
@@ -85,6 +85,7 @@ class MainWindow(MainWindowElement):
         self._application = application
         self.logger = logging.getLogger("MainWindow")
         self.__window = self._wtree.get_object("mainwindow")
+        self.__window.set_application(application)
         self._tabs = self._wtree.get_object("main_tabs")
         self._tabs.connect("switch-page", self._tab_switched)
         self.tabs = {}
@@ -273,7 +274,8 @@ class MainWindow(MainWindowElement):
             :param _button: Signaled Widget, unused
             :type _button: :class:`Gtk.ImageMenuItem`
             '''
-            _d = formbuilder.FormManagerGUI(self._config.form_source_dir(),
+            _d = formbuilder.FormManagerGUI(self._application,
+                                            self._config.form_source_dir(),
                                             config=self._config)
 
         def activate_ping(_button):

--- a/docs/source/d_rats.map.rst
+++ b/docs/source/d_rats.map.rst
@@ -84,14 +84,6 @@ d\_rats.map.maptile module
     :undoc-members:
     :show-inheritance:
 
-d\_rats.map.maptilecontext module
----------------------------------
-
-.. automodule:: d_rats.map.maptilecontext
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 d\_rats.map.mapwidget module
 ----------------------------
 

--- a/ui/mainwindow.glade
+++ b/ui/mainwindow.glade
@@ -167,7 +167,7 @@
       </row>
     </data>
   </object>
-  <object class="GtkWindow" id="mainwindow">
+  <object class="GtkApplicationWindow" id="mainwindow">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">D-RATS</property>
     <property name="default_width">640</property>


### PR DESCRIPTION
Need to convert to Gtk.ApplicationWindow as a first step of
migrating to the new supported menu APIs.

d_rats/formbuilder.py:
  Convert to use a Gtk.ApplicationWindow.

d_rats/mainwindow.py:
  Convert for using Gtk.ApplicationWindow.

ui/mainwindow.glade:
  Convert mainwindow to Gtk.ApplicationWindow.

docs/source/d_rats.map.rst:
  Remove non-existent maptilecontext entry.