### PR TITLE
fix(ui_main) code cleanup

### DIFF
--- a/d_rats/ui/main_chat.py
+++ b/d_rats/ui/main_chat.py
@@ -108,11 +108,11 @@ class ChatQM(MainWindowElement):
         }
 
     def __init__(self, wtree, config):
-        MainWindowElement.__init__(self, wtree, config, "chat", _("Chat"))
+        MainWindowElement.__init__(self, wtree, config, "chat")
         self.logger = logging.getLogger("ChatQM")
-        # pylint: disable=unbalanced-tuple-unpacking
-        qm_add, qm_rem, qm_list = self._getw("qm_add", "qm_remove",
-                                             "qm_list")
+        qm_add = self._get_widget("qm_add")
+        qm_rem = self._get_widget("qm_remove")
+        qm_list = self._get_widget("qm_list")
 
         store = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING)
         store.connect("row-deleted", self._reorder_rows)
@@ -228,14 +228,13 @@ class ChatQST(MainWindowElement):
         }
 
     def __init__(self, wtree, config):
-        MainWindowElement.__init__(self, wtree, config, "chat", _("Chat"))
+        MainWindowElement.__init__(self, wtree, config, "chat")
 
         self.logger = logging.getLogger("ChatQST")
-        # pylint: disable=unbalanced-tuple-unpacking
-        qst_add, qst_rem, qst_edit, qst_list = self._getw("qst_add",
-                                                          "qst_remove",
-                                                          "qst_edit",
-                                                          "qst_list")
+        qst_add = self._get_widget("qst_add")
+        qst_rem = self._get_widget("qst_remove")
+        qst_edit = self._get_widget("qst_edit")
+        qst_list = self._get_widget("qst_list")
 
         self._store = Gtk.ListStore(GObject.TYPE_STRING,
                                     GObject.TYPE_STRING,
@@ -526,13 +525,13 @@ class ChatTab(MainWindowTab):
     _signals = __gsignals__
 
     def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "chat", _("Chat"))
+        MainWindowTab.__init__(self, wtree, config, "chat")
 
         self.logger = logging.getLogger("ChatTab")
-        # pylint: disable=unbalanced-tuple-unpacking
-        entry, send, dest = self._getw("entry", "send", "destination")
-        # pylint: disable=unbalanced-tuple-unpacking
-        self.__filtertabs, = self._getw("filtertabs")
+        entry = self._get_widget("entry")
+        send = self._get_widget("send")
+        dest = self._get_widget("destination")
+        self.__filtertabs = self._get_widget("filtertabs")
         self.__filters = {}
 
         self.__filtertabs.remove_page(0)
@@ -1067,8 +1066,7 @@ class ChatTab(MainWindowTab):
         delfilter = self._config.ship_img("chat-delfilter.png")
         queryuser = self._config.ship_img("chat-query.png")
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        toolbar, = self._getw("toolbar")
+        toolbar = self._get_widget("toolbar")
         set_toolbar_buttons(self._config, toolbar)
 
         buttons = \
@@ -1241,8 +1239,7 @@ class ChatTab(MainWindowTab):
             self._reconfigure_colors(display.get_buffer())
             self._reconfigure_font(display)
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        dest, = self._getw("destination")
+        dest = self._get_widget("destination")
 
         self.__ports = []
         for port in self._config.options("ports"):
@@ -1270,8 +1267,7 @@ class ChatTab(MainWindowTab):
         :returns: Selected port text
         :rtype: str
         '''
-        # pylint: disable=unbalanced-tuple-unpacking
-        dest, = self._getw("destination")
+        dest = self._get_widget("destination")
         return dest.get_active_text()
 
     def selected(self):
@@ -1286,8 +1282,7 @@ class ChatTab(MainWindowTab):
             item = self._wtree.get_object(name)
             item.set_property("visible", True)
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        entry, = self._getw("entry")
+        entry = self._get_widget("entry")
         GLib.idle_add(entry.grab_focus)
 
     def deselected(self):

--- a/d_rats/ui/main_events.py
+++ b/d_rats/ui/main_events.py
@@ -279,14 +279,13 @@ class EventTab(MainWindowTab):
     _signals = __gsignals__
 
     def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "event", _("Event Log"))
+        MainWindowTab.__init__(self, wtree, config, "event")
 
         self.logger = logging.getLogger("EventTab")
 
         self.__ctr = 0
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        eventlist, = self._getw("list")
+        eventlist = self._get_widget("list")
 
         eventlist.connect("button_press_event", self._mouse_cb)
 
@@ -330,13 +329,11 @@ class EventTab(MainWindowTab):
         col = Gtk.TreeViewColumn(_("Description"), renderer, text=3)
         eventlist.append_column(col)
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        typesel, = self._getw("typesel")
+        typesel = self._get_widget("typesel")
         typesel.set_active(0)
         typesel.connect("changed", self._type_selected, event_filter)
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        filtertext, = self._getw("searchtext")
+        filtertext = self._get_widget("searchtext")
         filtertext.connect("changed", self._search_text, event_filter)
         utils.set_entry_hint(filtertext, FILTER_HINT)
 
@@ -512,8 +509,7 @@ class EventTab(MainWindowTab):
         :param event: Event to log.
         :type event: :class:`Event`
         '''
-        # pylint: disable=unbalanced-tuple-unpacking
-        scroll_window, = self._getw("sw")
+        scroll_window = self._get_widget("sw")
         adj = scroll_window.get_vadjustment()
         top_scrolled = (adj.get_value() == 0.0)
         bot_scrolled = (adj.get_value() ==

--- a/d_rats/ui/main_files.py
+++ b/d_rats/ui/main_files.py
@@ -267,11 +267,11 @@ class FilesTab(MainWindowTab):
     _signals = __gsignals__
 
     def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "files", _("Files"))
+        MainWindowTab.__init__(self, wtree, config, "files")
         self.logger = logging.getLogger("FilesTab")
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        lview, rview = self._getw("local_list", "remote_list")
+        lview = self._get_widget("local_list")
+        rview = self._get_widget("remote_list")
 
         self._setup_file_view(lview)
         self._setup_file_view(rview)
@@ -280,7 +280,7 @@ class FilesTab(MainWindowTab):
         # TODO
         # Not sure how to make this work for GTK+ ComboBox
         # Can live with out a hint while debugging
-        stations, = self._getw("sel_station")
+        stations = self._get_widget("sel_station")
         stn_entry = stations.get_child()
         utils.set_entry_hint(stn_entry, REMOTE_HINT)
 
@@ -302,8 +302,7 @@ class FilesTab(MainWindowTab):
         GLib.idle_add(self.emit, *args)
 
     def _stop_throb(self):
-        # pylint: disable=unbalanced-tuple-unpacking
-        throbber, = self._getw("remote_throb")
+        throbber = self._get_widget("remote_throb")
         pix = self._config.ship_img(THROB_IMAGE)
         throbber.set_from_pixbuf(pix)
 
@@ -328,7 +327,6 @@ class FilesTab(MainWindowTab):
             view.set_sensitive(False)
             view.get_model().clear()
         self._remote = None
-        # pylint: disable=unbalanced-tuple-unpacking
         ssel, psel = self._get_ssel()
         ssel.set_sensitive(True)
         psel.set_sensitive(True)
@@ -337,9 +335,7 @@ class FilesTab(MainWindowTab):
 
     def _connect_remote(self, _button, _rfview):
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        view, = self._getw("remote_list")
-        # pylint: disable=unbalanced-tuple-unpacking
+        view = self._get_widget("remote_list")
         ssel, psel = self._get_ssel()
         sta = ssel.get_active_text().upper()
         prt = psel.get_active_text()
@@ -350,8 +346,7 @@ class FilesTab(MainWindowTab):
         if not self._remote or self._remote.get_path() != sta:
             self._remote = RemoteFileView(view, sta, self._config)
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        throbber, = self._getw("remote_throb")
+        throbber = self._get_widget("remote_throb")
         img = self._config.ship_obj_fn(os.path.join("images", THROB_IMAGE))
         anim = GdkPixbuf.PixbufAnimation.new_from_file(img)
         throbber.set_from_animation(anim)
@@ -405,7 +400,6 @@ class FilesTab(MainWindowTab):
             if not file_name:
                 return
 
-        # pylint: disable=unbalanced-tuple-unpacking
         ssel, psel = self._get_ssel()
         port = psel.get_active_text()
 
@@ -427,7 +421,6 @@ class FilesTab(MainWindowTab):
         station = self._remote.get_path()
         file_name = self._remote.get_selected_filename()
 
-        # pylint: disable=unbalanced-tuple-unpacking
         _ssel, psel = self._get_ssel()
         port = psel.get_active_text()
 
@@ -459,7 +452,6 @@ class FilesTab(MainWindowTab):
 
         file_name = self._remote.get_selected_filename()
 
-        # pylint: disable=unbalanced-tuple-unpacking
         _ssel, psel = self._get_ssel()
         port = psel.get_active_text()
 
@@ -503,8 +495,7 @@ class FilesTab(MainWindowTab):
         dnload = self._config.ship_img("download.png")
         upload = self._config.ship_img("upload.png")
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        ltb, = self._getw("local_toolbar")
+        ltb = self._get_widget("local_toolbar")
         set_toolbar_buttons(self._config, ltb)
         lbuttons = \
             [(refresh, _("Refresh"), self._refresh_local, self._local),
@@ -514,8 +505,7 @@ class FilesTab(MainWindowTab):
 
         populate_tb(ltb, lbuttons)
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        rtb, = self._getw("remote_toolbar")
+        rtb = self._get_widget("remote_toolbar")
         set_toolbar_buttons(self._config, rtb)
         rbuttons = \
             [(connect, _("Connect"), self._connect_remote, self._remote),
@@ -591,7 +581,9 @@ class FilesTab(MainWindowTab):
         return self.__selected
 
     def _get_ssel(self):
-        return self._getw("sel_station", "sel_port")
+        sel_station = self._get_widget("sel_station")
+        sel_port = self._get_widget("sel_port")
+        return (sel_station, sel_port)
 
     def file_sent(self, name):
         '''
@@ -615,7 +607,6 @@ class FilesTab(MainWindowTab):
         '''Selected.'''
         MainWindowTab.selected(self)
         self.__selected = True
-        # pylint: disable=unbalanced-tuple-unpacking
         ssel, psel = self._get_ssel()
         self._refresh_calls(ssel, psel)
         GLib.timeout_add(1000, self._refresh_calls, ssel, psel)

--- a/d_rats/ui/main_messages.py
+++ b/d_rats/ui/main_messages.py
@@ -399,11 +399,10 @@ class MessageFolders(MainWindowElement):
 
     # MessageFolders
     def __init__(self, wtree, config):
-        MainWindowElement.__init__(self, wtree, config, "msg", _("Messages"))
+        MainWindowElement.__init__(self, wtree, config, "msg")
 
         self.logger = logging.getLogger("MessageFolders")
-        # pylint: disable=unbalanced-tuple-unpacking
-        folderlist, = self._getw("folderlist")
+        folderlist = self._get_widget("folderlist")
 
         store = Gtk.TreeStore(GObject.TYPE_STRING, GObject.TYPE_OBJECT)
         folderlist.set_model(store)
@@ -521,8 +520,7 @@ class MessageFolders(MainWindowElement):
         :param folder: Folder name to select
         :type folder: str
         '''
-        # pylint: disable=unbalanced-tuple-unpacking
-        view, = self._getw("folderlist")
+        view = self._get_widget("folderlist")
         store = view.get_model()
 
         msg_iter = store.get_iter_first()
@@ -808,11 +806,10 @@ class MessageList(MainWindowElement):
     # pylint wants a max of 50 statements for methods or functions
     # pylint: disable=too-many-statements
     def __init__(self, wtree, config):
-        MainWindowElement.__init__(self, wtree, config, "msg", _("Messages"))
+        MainWindowElement.__init__(self, wtree, config, "msg")
 
         self.logger = logging.getLogger("MessageList")
-        # pylint: disable=unbalanced-tuple-unpacking
-        msglist, = self._getw("msglist")
+        msglist = self._get_widget("msglist")
 
         self.store = Gtk.ListStore(GObject.TYPE_OBJECT,
                                    GObject.TYPE_STRING,
@@ -1115,8 +1112,7 @@ class MessageList(MainWindowElement):
 
     def delete_selected_messages(self):
         '''Delete Selected Messages.'''
-        # pylint: disable=unbalanced-tuple-unpacking
-        msglist, = self._getw("msglist")
+        msglist = self._get_widget("msglist")
 
         iters = []
         (store, paths) = msglist.get_selection().get_selected_rows()
@@ -1174,8 +1170,7 @@ class MessageList(MainWindowElement):
         :returns: List of selected messages
         :rtype: list
         '''
-        # pylint: disable=unbalanced-tuple-unpacking
-        msglist, = self._getw("msglist")
+        msglist = self._get_widget("msglist")
 
         selected = []
         (store, paths) = msglist.get_selection().get_selected_rows()
@@ -1206,7 +1201,7 @@ class MessagesTab(MainWindowTab):
     _signals = __gsignals__
 
     def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "msg", _("Messages"))
+        MainWindowTab.__init__(self, wtree, config, "msg")
 
         self.logger = logging.getLogger("MessagesTab")
         self._init_toolbar()
@@ -1571,8 +1566,7 @@ class MessagesTab(MainWindowTab):
         return menu
 
     def _init_toolbar(self):
-        # pylint: disable=unbalanced-tuple-unpacking
-        toolbar, = self._getw("toolbar")
+        toolbar = self._get_widget("toolbar")
 
         set_toolbar_buttons(self._config, toolbar)
 

--- a/d_rats/ui/main_stations.py
+++ b/d_rats/ui/main_stations.py
@@ -154,8 +154,7 @@ class StationsList(MainWindowTab):
         self.logger = logging.getLogger("StationsList")
         self.__smsg = None
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        _frame, self.__view, = self._getw("stations_frame", "stations_view")
+        self.__view = self._get_widget("stations_view")
 
         self.__status = None
         store = Gtk.ListStore(GObject.TYPE_STRING,  # Station
@@ -211,8 +210,8 @@ class StationsList(MainWindowTab):
         self.__calls = []
         self._update_station_count()
 
-        # pylint: disable=unbalanced-tuple-unpacking
-        status, msg = self._getw("stations_status", "stations_smsg")
+        status = self._get_widget("stations_status")
+        msg = self._get_widget("stations_smsg")
 
         try:
             tool_txt = _("This is the state other stations will "
@@ -550,8 +549,7 @@ class StationsList(MainWindowTab):
         menu.popup(None, None, None, None, event.button, event.time)
 
     def _update_station_count(self):
-        # pylint: disable=unbalanced-tuple-unpacking
-        hdr, = self._getw("stations_header")
+        hdr = self._get_widget("stations_header")
         if hdr:
             hdr.set_markup("<b>Stations (%i)</b>" % len(self.__calls))
         # pylint: disable=fixme
@@ -655,7 +653,7 @@ class StationsList(MainWindowTab):
         Get Stations.
 
         :returns: known stations
-        :rtype: list of :class:`station_status.Station`
+        :rtype: list[:class:`station_status.Station]`
         '''
         stations = []
         store = self.__view.get_model()


### PR DESCRIPTION
More code cleanup to be closer to current Python conventions.

d_rats/ui/main_chat.py:
d_rats/ui/main_common.py:
d_rats/ui/main_events.py:
d_rats/ui/main_files.py:
d_rats/ui/main_messages.py:
d_rats/ui/main_stations.py:
  Improve Docstrings.
  Fix lookup of menu tab text from glade file.