### PR TITLE
fix(main_common): API change

### DIFF
--- a/d_rats/ui/main_chat.py
+++ b/d_rats/ui/main_chat.py
@@ -525,7 +525,7 @@ class ChatTab(MainWindowTab):
     _signals = __gsignals__
 
     def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "chat")
+        MainWindowTab.__init__(self, wtree, config, prefix="chat")
 
         self.logger = logging.getLogger("ChatTab")
         entry = self._get_widget("entry")

--- a/d_rats/ui/main_common.py
+++ b/d_rats/ui/main_common.py
@@ -193,12 +193,14 @@ class MainWindowElement(GObject.GObject):
     :type wtree: :class:`Gtk.Widget`
     :param config: Configuration data
     :type config: :class:`DratsConfig`
-    :param prefix: Prefix for the widget name lookups
+    :param prefix: Prefix for the widget name lookups, default None
     :type prefix: str
     '''
 
-    def __init__(self, wtree, config, prefix):
+    def __init__(self, wtree, config, prefix=None):
         self._prefix = prefix
+        if not self._prefix:
+            self._prefix = ''
         self._wtree = wtree
         self._config = config
 
@@ -228,13 +230,15 @@ class MainWindowTab(MainWindowElement):
     :type wtree: :class:`Gtk.Widget`
     :param config: Configuration data
     :type config: :class:`DratsConfig`
-    :param prefix: Prefix for lookups
+    :param window: Mainwindow window widget, Default None
+    :type: window: :class:`Gtk.ApplicationWindow`
+    :param prefix: Prefix for lookups, Default None
     :type prefix: str
     '''
 
-    def __init__(self, wtree, config, prefix):
+    def __init__(self, wtree, config, window=None, prefix=None):
         MainWindowElement.__init__(self, wtree, config, prefix)
-        self._prefix = prefix
+        self.window = window
         self._notebook = wtree.get_object('main_tabs')
         self._menu_tab = wtree.get_object("tab_label_%s" % prefix)
         self._tab_label = None

--- a/d_rats/ui/main_events.py
+++ b/d_rats/ui/main_events.py
@@ -265,6 +265,8 @@ class EventTab(MainWindowTab):
     :type wtree: :class:`Gtk.Widget`
     :param config: D-Rats configuration
     :type config: :class:`DratsConfig`
+    :param window: Mainwindow window widget
+    :type: window: :class:`Gtk.ApplicationWindow`
     '''
 
     __gsignals__ = {
@@ -278,8 +280,9 @@ class EventTab(MainWindowTab):
 
     _signals = __gsignals__
 
-    def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "event")
+    def __init__(self, wtree, config, window):
+        MainWindowTab.__init__(self, wtree, config,
+                               window=window, prefix="event")
 
         self.logger = logging.getLogger("EventTab")
 

--- a/d_rats/ui/main_files.py
+++ b/d_rats/ui/main_files.py
@@ -267,7 +267,7 @@ class FilesTab(MainWindowTab):
     _signals = __gsignals__
 
     def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "files")
+        MainWindowTab.__init__(self, wtree, config, prefix="files")
         self.logger = logging.getLogger("FilesTab")
 
         lview = self._get_widget("local_list")

--- a/d_rats/ui/main_messages.py
+++ b/d_rats/ui/main_messages.py
@@ -72,6 +72,8 @@ class MessagesTab(MainWindowTab):
     :type wtree: :class:`Gtk.GtkNotebook`
     :param config: Configuration data
     :type config: :class:`DratsConfig`
+    :param window: Mainwindow window widget
+    :type: window: :class:`Gtk.ApplicationWindow`
     '''
 
     __gsignals__ = {
@@ -84,8 +86,8 @@ class MessagesTab(MainWindowTab):
 
     _signals = __gsignals__
 
-    def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "msg")
+    def __init__(self, wtree, config, window):
+        MainWindowTab.__init__(self, wtree, config, window=window, prefix="msg")
 
         self.logger = logging.getLogger("MessagesTab")
         self._init_toolbar()

--- a/d_rats/ui/main_stations.py
+++ b/d_rats/ui/main_stations.py
@@ -130,6 +130,8 @@ class StationsList(MainWindowTab):
     :param wtree: Window object
     :param config: Configuration data
     :type config: :class:`DratsConfig`
+    :param window: Mainwindow window widget
+    :type: window: :class:`Gtk.ApplicationWindow`
     '''
 
     __gsignals__ = {
@@ -148,8 +150,9 @@ class StationsList(MainWindowTab):
     # pylint wants no more than 15 local variables
     # pylint wants no more than 50 statements
     # pylint: disable=too-many-statements, too-many-locals
-    def __init__(self, wtree, config):
-        MainWindowTab.__init__(self, wtree, config, "main")
+    def __init__(self, wtree, config, window):
+        MainWindowTab.__init__(self, wtree, config,
+                               window=window, prefix="main")
 
         self.logger = logging.getLogger("StationsList")
         self.__smsg = None


### PR DESCRIPTION
The new Gio menu system needs access to the Gtk.ApplicationWindow
object of the mainWindow object.

d_rats/mainwindow.py:
  Pass Gtk.ApplicationWindow object as optional parameter.
  Update the unit test to do something.

d_rats/ui/main_common.py:
  Fix up MainWindowElement and MainWindowTab classes For
  handling optional prefix and window parameters.

d_rats/ui/main_chat.py:
d_rats/ui/main_events.py:
d_rats/ui/main_messages.py:
d_rats/ui/main_stations.py:
  Fix up for API change.