### PR TITLE
fix(main_event): Implement popup menu

### DIFF
--- a/d_rats/ui/event_popup_model.py
+++ b/d_rats/ui/event_popup_model.py
@@ -1,0 +1,111 @@
+'''Main Event Mouse Popup Menu Model.'''
+#
+# Copyright 2022 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gio
+
+
+# This makes pylance happy with out overriding settings
+# from the invoker of the class
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+class EventPopupModel(Gio.Menu):
+    '''
+    Creates the Popup Menu for Mouse Click in the Message Window.
+
+    :param widget: The message folder widget
+    :type widget: :class:`MessageFolders`
+    '''
+
+    MENU_ACTIONS = [("stop", _("Stop"), None),
+                    ("cancel", _("Cancel"), None),
+                    ("restart", _("Restart"), None)]
+
+    event_object = None
+
+    def __init__(self, widget):
+        Gio.Menu.__init__(self)
+
+        self.actions = {}
+        # The actual popup menu has to be in a section.
+        menu_popup = Gio.Menu()
+
+        for action_name, label, _icon_file, in self.MENU_ACTIONS:
+            # The action name needs a "win." prefix
+            menu_item = Gio.MenuItem.new(label, "win.%s" % action_name)
+            menu_popup.append_item(menu_item)
+            action = Gio.SimpleAction(name=action_name,
+                                      parameter_type=None,
+                                      enabled=True)
+            # This does not work, the icon does not display.
+            # if _icon_file:
+            #    icon_path = widget.config.ship_obj_fn(
+            #        os.path.join("images", icon_file))
+            #    gio_file = Gio.File.new_for_path(icon_path)
+            #    file_icon = Gio.FileIcon.new(gio_file)
+            #    menu_item.set_icon(file_icon)
+            widget.window.add_action(action)
+            action.connect('activate', widget.popup_menu_handler)
+            self.actions[action_name] = action
+        self.append_section(None, menu_popup)
+
+    @classmethod
+    def _menu_params(cls, event):
+        '''
+        Store parameter for current menu selection
+
+        The Gio Action handlers can only handle simple types, not anything
+        as complex as the specific GTK widgets that we want to use in the
+        handler.
+
+        Taking advantage that there will only be one active instance
+        of the popup menu using this model active ever, we can also
+        use class storage of this method to pass the parameters.
+
+        :param event: Session Event for menu to act on.
+        :type event: class:`event.SessionEvent`
+        '''
+        cls.event_object = event
+
+    def change_state(self, event):
+        '''
+        Update state to current selection.
+
+        :param event: Event for menu to act on.
+        :type event: :class:`event.Event`
+        '''
+        self._menu_params(event)
+
+        for action_name, _label, _icon in self.MENU_ACTIONS:
+            if action_name == "restart":
+                restart_info = event.get_restart_info()
+                enable = restart_info is not None
+            else:
+                enable = not event.is_final()
+            self.actions[action_name].set_enabled(enable)

--- a/d_rats/ui/message_list.py
+++ b/d_rats/ui/message_list.py
@@ -88,7 +88,7 @@ def bold_if_unread(_col, rend, model, tree_iter, cnum):
     Bold if Unread Cell Layout Data Function.
 
     :param _col: Cell layout, unused
-    :type _col: :class:`Gtk.CellLayout
+    :type _col: :class:`Gtk.CellLayout`
     :param rend: Cell Renderer
     :type rend: :class:`Gtk.CellRendererText`
     :param model: Tree Model
@@ -113,7 +113,7 @@ def render_date(_col, rend, model, tree_iter, _cnum):
     Render Date Cell Layout Data Function.
 
     :param _col: Cell layout, unused
-    :type _col: :class:`Gtk.CellLayout
+    :type _col: :class:`Gtk.CellLayout`
     :param rend: Cell Renderer
     :type rend: :class:`Gtk.CellRendererText`
     :param model: Tree Model

--- a/docs/source/d_rats.ui.rst
+++ b/docs/source/d_rats.ui.rst
@@ -12,6 +12,22 @@ d\_rats.ui.conntest module
     :undoc-members:
     :show-inheritance:
 
+d\_rats.ui.event\_popup\_model module
+-------------------------------------
+
+.. automodule:: d_rats.ui.event_popup_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+d\_rats.ui.event\_tab module
+----------------------------
+
+.. automodule:: d_rats.ui.event_tab
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 d\_rats.ui.main\_chat module
 ----------------------------
 
@@ -56,6 +72,38 @@ d\_rats.ui.main\_stations module
 --------------------------------
 
 .. automodule:: d_rats.ui.main_stations
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+d\_rats.ui.message\_folder\_info module
+---------------------------------------
+
+.. automodule:: d_rats.ui.message_folder_info
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+d\_rats.ui.message\_folders module
+----------------------------------
+
+.. automodule:: d_rats.ui.message_folders
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+d\_rats.ui.message\_list module
+-------------------------------
+
+.. automodule:: d_rats.ui.message_list
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+d\_rats.ui.message\_popup\_model module
+---------------------------------------
+
+.. automodule:: d_rats.ui.message_popup_model
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Implement the Mouse Popup Menu for events.

d_rats/ui/event_popup_model.py:
  New module for EventPopupModel class.

d_rats/ui/event_tab.py:
  Use EventPopupModel to implement mouse popup menu.

d_rats/ui/message_list.py:
  Fix broken Docstrings.

docs/source/d_rats.ui.rst:
  Add new modules for message and event classes.