### PR TITLE
fix(option): Fix config option

### DIFF
--- a/d-rats.py
+++ b/d-rats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# "d-rats.py" does not comply with Snake Case nameing, so must suppress this.
+# "d-rats.py" does not comply with Snake Case naming, so must suppress this.
 # pylint: disable=invalid-name
 '''d-rats main program'''
 #
@@ -56,16 +56,16 @@ IGNORE_ALL = False
 # here we design the window which usually comes out at the beginning asking
 # to "ignore/ignore all" the exceptions
 
-def handle_exception(exctyp, value, tb):
+def handle_exception(except_type, value, trace_back):
     '''
     Handle Exception.
 
-    :param exctyp: Exception type
-    :type exctype: type
+    :param except_type: Exception type
+    :type except_type: type
     :param value: Exception value
     :type value: Exception
-    :param tb: Traceback
-    :type tb: traceback
+    :param trace_back: Traceback
+    :type trace_back: traceback
     '''
 
     # this eventually starts the initial window with the list of errors and the
@@ -75,8 +75,8 @@ def handle_exception(exctyp, value, tb):
     # pylint: disable=global-statement
     global IGNORE_ALL
 
-    if exctyp is KeyboardInterrupt or IGNORE_ALL:
-        return sys.__excepthook__(exctyp, value, tb)
+    if except_type is KeyboardInterrupt or IGNORE_ALL:
+        return sys.__excepthook__(except_type, value, trace_back)
 
     # Gdk.pointer_ungrab(Gdk.CURRENT_TIME)
     # Gdk.keyboard_ungrab(Gdk.CURRENT_TIME)
@@ -87,7 +87,7 @@ def handle_exception(exctyp, value, tb):
     # Other documentation indicates that most grabs and un-grabs may
     # not be needed for Gtk 3
 
-    _trace = traceback.format_exception(exctyp, value, tb)
+    _trace = traceback.format_exception(except_type, value, trace_back)
     trace = os.linesep.join(_trace)
 
     MODULE_LOGGER.info("---- GUI Exception ----\n%s\n---- End ----\n",
@@ -204,7 +204,8 @@ def main():
 
     if args.config:
         MODULE_LOGGER.info("main: re-config option found -- Reconfigure D-rats")
-        dplatform.get_platform(args.config)
+        MODULE_LOGGER.info("main: args.config = %s", args.config)
+        platform.set_base_dir(args.config)
 
     # import the D-Rats main application
     from d_rats import mainapp

--- a/d-rats_repeater.py
+++ b/d-rats_repeater.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''D-Rats Repeater.'''
-# pylint wants only 100 lines per module.
+# pylint wants only 1000 lines per module.
 # pylint does not like the module name, wants "snake_case" compliance.
 # pylint: disable=too-many-lines, invalid-name
 #
@@ -482,7 +482,9 @@ class RepeaterUI:
         return config
 
     # pylint wants a max of 15 local variables
-    # pylint: disable=too-many-locals
+    # pylint wants a max of 50 statements
+    # pylint wants a max of 12 branches
+    # pylint: disable=too-many-locals, too-many-statements, too-many-branches
     def add_outgoing_paths(self, ident, paths):
         '''
         Add outgoing paths.
@@ -1224,6 +1226,8 @@ def main():
     platform = dplatform.get_platform()
     def_config_dir = platform.config_dir()
 
+    # pylint wants at least 2 public methods, but we do not need them
+    # since this is extending another class.
     # pylint: disable=too-few-public-methods
     class LoglevelAction(argparse.Action):
         '''
@@ -1296,7 +1300,7 @@ def main():
             level=args.loglevel)
 
     if args.config:
-        dplatform.get_platform(args.config)
+        platform.set_base_dir(args.config)
 
     if args.console:
         repeater = RepeaterConsole()

--- a/d_rats/dplatform.py
+++ b/d_rats/dplatform.py
@@ -26,10 +26,9 @@ import os
 import sys
 import glob
 import subprocess
-import six.moves.urllib.request # type: ignore
-import six.moves.urllib.parse # type: ignore
-import six.moves.urllib.error # type: ignore
-from six.moves import range # type: ignore
+import urllib.request
+import urllib.parse
+import urllib.error
 
 
 if '_' not in locals():
@@ -60,7 +59,7 @@ class Platform():
 
     def __init__(self, basepath):
         self.logger = logging.getLogger("Platform")
-        self._base = basepath
+        self.set_base_dir(basepath)
         my_dir = os.path.realpath(os.path.dirname(__file__))
         self._source_dir = os.path.dirname(my_dir)
         self._connected = True
@@ -72,6 +71,15 @@ class Platform():
         text.append("  OS version: %s" % self.os_version_string())
 
         return os.linesep.join(text)
+
+    def set_base_dir(self, basepath):
+        '''
+        Set the base directory.
+
+        :param basepath: Base directory
+        :type basepath: str
+        '''
+        self._base = basepath
 
     def config_dir(self):
         '''
@@ -104,8 +112,8 @@ class Platform():
 
         return logdir
 
-    # pylint: disable=no-self-use
-    def filter_filename(self, filename):
+    @staticmethod
+    def filter_filename(filename):
         '''
         Filter Filename.
 
@@ -158,8 +166,8 @@ class Platform():
         '''
         raise NotImplementedError("The base class can't do that")
 
-    # pylint: disable=no-self-use
-    def list_serial_ports(self):
+    @staticmethod
+    def list_serial_ports():
         '''
         List Serial Ports.
 
@@ -168,8 +176,8 @@ class Platform():
         '''
         return []
 
-    # pylint: disable=no-self-use
-    def default_dir(self):
+    @staticmethod
+    def default_dir():
         '''
         Default Directory.
 
@@ -178,8 +186,8 @@ class Platform():
         '''
         return "."
 
-    # pylint: disable=no-self-use
-    def gui_open_file(self, start_dir=None):
+    @staticmethod
+    def gui_open_file(start_dir=None):
         '''
         GUI Open File.
 
@@ -209,8 +217,8 @@ class Platform():
             return fname
         return None
 
-    # pylint: disable=no-self-use
-    def gui_save_file(self, start_dir=None, default_name=None):
+    @staticmethod
+    def gui_save_file(start_dir=None, default_name=None):
         '''
         GUI Save File.
 
@@ -245,8 +253,8 @@ class Platform():
             return fname
         return None
 
-    # pylint: disable=no-self-use
-    def gui_select_dir(self, start_dir=None):
+    @staticmethod
+    def gui_select_dir(start_dir=None):
         '''
         Gui Select Directory.
 
@@ -278,8 +286,8 @@ class Platform():
             return fname
         return None
 
-    # pylint: disable=no-self-use
-    def os_version_string(self):
+    @staticmethod
+    def os_version_string():
         '''
         OS Version String.
 
@@ -313,7 +321,7 @@ class Platform():
         :returns: Data from URL
         '''
         if self._connected:
-            return six.moves.urllib.request.urlretrieve(url)
+            return urllib.request.urlretrieve(url)
 
         raise NotConnectedError("Not connected")
 
@@ -326,7 +334,6 @@ class Platform():
         '''
         self._connected = connected
 
-    # pylint: disable=no-self-use
     def play_sound(self, _soundfile):
         '''
         Play Sound.
@@ -349,13 +356,22 @@ class UnixPlatform(Platform):
 
     def __init__(self, basepath):
         self.logger = logging.getLogger("UnixPlatform")
+        self.set_base_dir(basepath)
+        Platform.__init__(self, basepath)
+
+    def set_base_dir(self, basepath):
+        '''
+        Set the base directory.
+
+        :param basepath: Base directory
+        :type basepath: str
+        '''
         if not basepath:
             basepath = os.path.abspath(os.path.join(self.default_dir(),
                                                     ".d-rats-ev"))
         if not os.path.isdir(basepath):
             os.mkdir(basepath)
-
-        Platform.__init__(self, basepath)
+        self._base = basepath
 
     def source_dir(self):
         '''
@@ -381,8 +397,8 @@ class UnixPlatform(Platform):
         '''
         return os.path.abspath(os.getenv("HOME"))
 
-    # pylint: disable=no-self-use
-    def filter_filename(self, filename):
+    @staticmethod
+    def filter_filename(filename):
         '''
         Filter Filename.
 
@@ -393,7 +409,6 @@ class UnixPlatform(Platform):
         '''
         return filename.replace("/", "")
 
-    # pylint: disable=no-self-use
     def _unix_doublefork_run(self, *args):
         pid1 = os.fork()
         if pid1 == 0:
@@ -608,6 +623,17 @@ class Win32Platform(Platform):
 
     def __init__(self, basepath=None):
         self.logger = logging.getLogger("Win32Platform")
+        self.set_base_dir(basepath)
+
+        Platform.__init__(self, basepath)
+
+    def set_base_dir(self, basepath):
+        '''
+        Set the base directory.
+
+        :param basepath: Base directory
+        :type basepath: str
+        '''
         if not basepath:
             appdata = os.getenv("APPDATA")
             if not appdata:
@@ -616,8 +642,7 @@ class Win32Platform(Platform):
 
         if not os.path.isdir(basepath):
             os.mkdir(basepath)
-
-        Platform.__init__(self, basepath)
+        self._base = basepath
 
     def default_dir(self):
         '''
@@ -668,6 +693,7 @@ class Win32Platform(Platform):
         :returns: List of serial ports
         :rtype: list[str]
         '''
+        # pylint not handing cross-platform import checks
         # pylint: disable=import-error
         try:
             import win32file # type: ignore
@@ -711,6 +737,7 @@ class Win32Platform(Platform):
         :returns: Filename to open or none.
         :rtype: str
         '''
+        # pylint not handing cross-platform import checks
         # pylint: disable=import-error
         try:
             import win32gui # type: ignore
@@ -738,6 +765,7 @@ class Win32Platform(Platform):
         :returns: filename to save to or None
         :rtype: str
         '''
+        # pylint not handing cross-platform import checks
         # pylint: disable=import-error
         try:
             import win32gui # type: ignore
@@ -761,9 +789,10 @@ class Win32Platform(Platform):
 
         :param start_dir: directory to start in, default None
         :type start_dir: str
-        :returns: selected diretory or None
+        :returns: selected directory or None
         :rtype: str
         '''
+        # pylint not handing cross-platform import checks
         # pylint: disable=import-error
         try:
             from win32com.shell import shell # type: ignore
@@ -793,6 +822,7 @@ class Win32Platform(Platform):
         :returns: Platform version string
         :rtype: str
         '''
+        # pylint not handing cross-platform import checks
         # pylint: disable=import-error, unused-import
         try:
             import win32api # type: ignore
@@ -810,6 +840,7 @@ class Win32Platform(Platform):
                 "5.1": "Windows XP",
                 "5.0": "Windows 2000",
                }
+        # pylint not handing cross-platform import checks
         # pylint: disable=undefined-variable
         (major_version, minor_version, _build_number, _platform_id, _version) \
             = win32api.GetVersionEx() # type: ignore
@@ -825,6 +856,7 @@ class Win32Platform(Platform):
         :param soundfile: file to play sound from
         :type soundfile: str
         '''
+        # pylint not handing cross-platform import checks
         # pylint: disable=import-error
         import winsound
 


### PR DESCRIPTION
Fix setting the config directory option

d-rats.py:
d-rats_repeater.py:
  Use new platform set_base_dir method.
  Code Cleanup to be closer to current Python conventions.

d_rats/dplatform.py:
  Add set_base_dir method to allow changing the base directory.
  Remove python2 compatibility code.