### PR TITLE
fix(main_station): Code cleanup

### DIFF
--- a/d_rats/sessions/rpc.py
+++ b/d_rats/sessions/rpc.py
@@ -543,27 +543,20 @@ class RPCCheckMail(RPCJob):
         '''
         return rpcactions.rpc_check_mail(self)
 
-    # pylint: disable=too-many-arguments
-    def set_account(self, host, user, pasw, port, ssl):
+    # This could be optimized more.  Leaving as is to be consistent
+    # with how the rest of this module is coded.
+    def set_account(self, account):
         '''
         Set Mail Account.
 
-        :param host: TCP/IP Host name
-        :type host: str
-        :param user: User name
-        :type user: str
-        :param pasw: Password for user
-        :type pasw: str
-        :param port: TCP/IP port
-        :type port: str
-        :param ssl: SSL flag of 'True' or 'False'
-        :type sst: str
+        :param account: Remote account information
+        :type account: :class:`d_rats.ui.AccountDialog`
         '''
-        self._args = {"host" : host,
-                      "user" : user,
-                      "pasw" : pasw,
-                      "port" : port,
-                      "ssl"  : ssl,
+        self._args = {"host" : account.host,
+                      "user" : account.username,
+                      "pasw" : account.password,
+                      "port" : str(account.port),
+                      "ssl"  : str(account.use_ssl)
                       }
 
     def get_account(self):

--- a/d_rats/ui/account_dialog.py
+++ b/d_rats/ui/account_dialog.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python
+'''Account Dialog'''
+#
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+from d_rats import miscwidgets
+from d_rats import inputdialog
+
+
+if not '_' in locals():
+    import gettext
+    _ = gettext.gettext
+
+
+# This needs some improvement
+# Should have a check to see if the config of the mail accounts has changed.
+# also this is currently is apparently only used for querying if a remote
+# d-rats station has undelivered messages for this host, as most of the
+# information is not passed to the RPC session.
+
+class AccountDialog:
+    '''
+    Account Dialog.
+
+    :param config: Configuration data
+    :type config: :class:`DratsConfig`
+    '''
+
+    HOST = 0
+    USER = 1
+    PASSWORD = 2
+    USE_SSL = 3
+    PORT = 4
+
+    def __init__(self, config):
+        self._config = config
+        self._accounts = {}
+        self._default_account = None
+        self._fields = [None, None, None, None, None]
+        self._dialog = None
+        self._disable = None
+        self._account = None
+
+    @property
+    def host(self):
+        '''
+        :returns: Host name
+        :rtype: str
+        '''
+        return self._fields[self.HOST].get_text()
+
+    @property
+    def username(self):
+        '''
+        :returns username
+        :rtype: str
+        '''
+        return self._fields[self.USER].get_text()
+
+    @property
+    def password(self):
+        '''
+        :returns: password
+        :rtype: str
+        '''
+        return self._fields[self.PASSWORD].get_text()
+
+    @property
+    def use_ssl(self):
+        '''
+        :returns: True if use ssl
+        :rtype: bool
+        '''
+        return bool(self._fields[self.USE_SSL].get_active())
+
+    @property
+    def port(self):
+        '''
+        :returns: Port number
+        :rtype: int
+        '''
+        return int(self._fields[self.PORT].get_value())
+
+    def _get_accounts(self):
+        '''Get Dictionary of Accounts.'''
+
+        for section in self._config.options("incoming_email"):
+            info = self._config.get("incoming_email", section).split(",")
+            key = "%s on %s" % (info[1], info[0])
+            if not self._default_account:
+                self._default_account = key
+            self._accounts[key] = info
+
+        wl2k_call = self._config.get("user", "callsign")
+        wl2k_ssid = self._config.get("prefs", "msg_wl2k_ssid").strip()
+        if wl2k_ssid:
+            wl2k_call = "%s-%s" % (wl2k_call, wl2k_ssid)
+
+        self._accounts["Other"] = ["", "", "", "", "", "110"]
+        if not self._default_account:
+            self._default_account = "Other"
+        self._accounts["WL2K"] = ["@WL2K", wl2k_call, "", "", "", "0"]
+
+    def _choose_account(self, box):
+        '''
+        Box Changed handler.
+
+        :param box: ComboBoxText widget.
+        :type box: :class:`Gtk.ComboBoxText`
+        '''
+        info = self._accounts[box.get_active_text()]
+        for i in self._fields:
+            i.set_sensitive(not info[0])
+        self._fields[self.HOST].set_text(info[0])
+        self._fields[self.USER].set_text(info[1])
+        self._fields[self.PASSWORD].set_text(info[2])
+        self._fields[self.USE_SSL].set_active(info[4] == "True")
+        self._fields[self.PORT].set_value(int(info[5]))
+
+    def _set_fields(self):
+        '''
+        Set Fields Internal.
+
+        The field widgets need to be recreated fro each dialog run.
+        '''
+        if not self._accounts:
+            self._get_accounts()
+
+        account_list = list(self._accounts.keys())
+        self._account = miscwidgets.make_choice(account_list, False,
+                                                self._default_account)
+        self._fields[self.HOST] = Gtk.Entry()
+        self._fields[self.USER] = Gtk.Entry()
+        self._fields[self.PASSWORD] = Gtk.Entry()
+        self._fields[self.USE_SSL] = Gtk.CheckButton()
+        self._fields[self.PORT] = Gtk.SpinButton()
+        self._fields[self.PORT].set_adjustment(
+            Gtk.Adjustment.new(110, 1, 65535, 1, 0, 0))
+        self._fields[self.PORT].set_digits(0)
+
+        self._fields[self.PASSWORD].set_visibility(False)
+
+        self._account.connect("changed", self._choose_account)
+
+
+    def _get_dialog(self):
+        self._set_fields()
+
+        self._dialog = inputdialog.FieldDialog(title=_("Select account"))
+        self._dialog.add_field(_("Account"), self._account)
+        self._dialog.add_field(_("Server"), self._fields[self.HOST])
+        self._dialog.add_field(_("Username"), self._fields[self.USER])
+        self._dialog.add_field(_("Password"), self._fields[self.PASSWORD])
+        self._dialog.add_field(_("Use SSL"), self._fields[self.USE_SSL])
+        self._dialog.add_field(_("Port"), self._fields[self.PORT])
+        return self._dialog
+
+    def prompt_for_account(self):
+        '''
+        Prompt for account.
+
+        '''
+        dialog = self._get_dialog()
+        result = dialog.run()
+        self._dialog = None
+        dialog.destroy()
+        if result == Gtk.ResponseType.OK:
+            return True
+        return False

--- a/d_rats/ui/event_popup_model.py
+++ b/d_rats/ui/event_popup_model.py
@@ -37,7 +37,7 @@ if not '_' in locals():
 
 class EventPopupModel(Gio.Menu):
     '''
-    Creates the Popup Menu for Mouse Click in the Message Window.
+    Creates the Popup Menu for Mouse Click in the Event Window Tab.
 
     :param widget: The message folder widget
     :type widget: :class:`MessageFolders`

--- a/d_rats/ui/message_popup_model.py
+++ b/d_rats/ui/message_popup_model.py
@@ -37,7 +37,7 @@ if not '_' in locals():
 
 class MessagePopupModel(Gio.Menu):
     '''
-    Creates the Popup Menu for Mouse Click in the Message Window.
+    Creates the Popup Menu for Mouse Click in the Message Window Tab.
 
     :param widget: The message folder widget
     :type widget: :class:`MessageFolders`

--- a/docs/source/d_rats.ui.rst
+++ b/docs/source/d_rats.ui.rst
@@ -4,6 +4,14 @@ d\_rats.ui package
 Submodules
 ----------
 
+d\_rats.ui.account\_dialog module
+---------------------------------
+
+.. automodule:: d_rats.ui.account_dialog
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 d\_rats.ui.conntest module
 --------------------------
 


### PR DESCRIPTION
Convert to current python programming conventions.

d_rats/ui/account_dialog.py:
  Refactored from d_rats/ui/main_station.py into a class.

d_rats/ui/main_stations.py:
  Refactor account dialog into its own module.
  Refactor code to remove pylint diagnostics

d_rats/sessions/rpc.py:
  Pass account object instead of many parameters.

d_rats/ui/event_popup_model.py:
d_rats/ui/message_popup_model.py:
  Fix comments

docs/source/d_rats.ui.rst:
  Add d_rats/ui/account_dialog to documentation generation.