### PR TITLE
fix(mainwindow): Code cleanup

### DIFF
--- a/d_rats/ui/main_chat.py
+++ b/d_rats/ui/main_chat.py
@@ -587,6 +587,19 @@ class ChatTab(MainWindowTab):
 
         self.reconfigure()
 
+    def display_info(self, text, *attrs):
+        '''
+        Display Information.
+
+        This is used to display startup information
+
+        :param text: Text to display
+        :type text: str
+        :param attrs: Additional attributes
+        :type attrs: tuple[str]
+        '''
+        self._display_line(text, True, *attrs)
+
     def display_line(self, text, incoming, *attrs, **kwargs):
         '''
         Display a single line of text with a date stamp.


### PR DESCRIPTION
Convert mainwindow.py to current python programming conventions.

d_rats/mainwindow.py:
  Move self.logger to be a class variable.
  Change hidden protected __window property to just be protected.
  Use new ChatTab.display_info method for startup messages.
  Refactor handler functions into their own methods.

d_rats/ui/main_chat.py:
  Add display_info method.