### PR TITLE
Fixes for deprecated menu APIs.

### DIFF
--- a/d_rats/mainwindow.py
+++ b/d_rats/mainwindow.py
@@ -242,7 +242,7 @@ class MainWindow(MainWindowElement):
         :param _button: Signaled Widget, unused
         :type _button: :class:`Gtk.ImageMenuItem`
         '''
-        saved = self._config.show(parent=self.window)
+        saved = self._config.show(parent=self._window)
         if saved:
             self.emit("config-changed")
             for tabs in self.tabs.values():

--- a/d_rats/mainwindow.py
+++ b/d_rats/mainwindow.py
@@ -370,9 +370,7 @@ class MainWindow(MainWindowElement):
     def _connect_menu_items(self):
 
         menu_quit = self._wtree.get_object("main_menu_quit")
-        add_menu_accel_theme_image(menu_quit, "application-exit",
-                                   _("Quit"), "Q",
-                                   Gdk.ModifierType.CONTROL_MASK)
+        add_menu_accel_theme_image(menu_quit, "application-exit", _("Quit"))
         menu_quit.connect("activate", self._activate_save_and_quit)
 
         about = self._wtree.get_object("main_menu_about")
@@ -384,14 +382,11 @@ class MainWindow(MainWindowElement):
 
         menu_prefs = self._wtree.get_object("main_menu_prefs")
         add_menu_accel_theme_image(menu_prefs, "preferences-system",
-                                   _("Preferences"), "P",
-                                   Gdk.ModifierType.MOD1_MASK)
+                                   _("Preferences"))
         menu_prefs.connect("activate", self._activate_prefs)
 
         menu_map = self._wtree.get_object("main_menu_map")
-        add_menu_accel_file_image(menu_map, "images/map.png",
-                                  _("Map"), "M",
-                                  Gdk.ModifierType.CONTROL_MASK)
+        add_menu_accel_file_image(menu_map, "images/map.png", _("Map"))
         menu_map.connect("activate", self._activate_map)
 
         menu_templates = self._wtree.get_object("main_menu_msgtemplates")
@@ -399,8 +394,7 @@ class MainWindow(MainWindowElement):
 
         ping = self._wtree.get_object("main_menu_ping")
         add_menu_accel_file_image(ping, "images/event_ping.png",
-                                  _("Ping Station"), "P",
-                                  Gdk.ModifierType.CONTROL_MASK)
+                                  ("Ping Station"))
         ping.connect("activate", self._activate_ping)
 
         conn = self._wtree.get_object("main_menu_conninet")

--- a/d_rats/mainwindow.py
+++ b/d_rats/mainwindow.py
@@ -30,6 +30,7 @@ import subprocess
 
 import gi
 gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import GLib
 
@@ -42,8 +43,13 @@ from d_rats.ui.main_chat import ChatTab
 from d_rats.ui.event_tab import EventTab
 from d_rats.ui.main_files import FilesTab
 from d_rats.ui.main_stations import StationsList
-from d_rats.ui.main_common import MainWindowElement, prompt_for_station, \
-    ask_for_confirmation
+from d_rats.ui.main_common import MainWindowElement
+from d_rats.ui.main_common import prompt_for_station
+from d_rats.ui.main_common import ask_for_confirmation
+
+from d_rats.menu_helpers import add_menu_theme_image
+from d_rats.menu_helpers import add_menu_accel_file_image
+from d_rats.menu_helpers import add_menu_accel_theme_image
 
 from d_rats.version import \
     DRATS_VERSION, \
@@ -134,45 +140,42 @@ class MainWindow(MainWindowElement):
 
         GLib.timeout_add(3000, self.__update_status)
 
-    def _delete(self, window, _event):
+    def _delete(self, window, event):
         '''
         Delete Event Handler.
 
         :param window: window
         :type window: :class:`Gtk.Window`
-        :param _event: Event widget, not used
-        :type _event: :class:`Gtk.Event`
+        :param event: Event widget, not used
+        :type event: :class:`Gtk.Event`
         :returns: False if program should actually exit
         :rtype: bool
         '''
+        self.logger.info("_delete handler invoked %s", type(event) )
         if self._config.getboolean("prefs", "confirm_exit"):
             if not ask_for_confirmation("Really exit D-RATS?", window):
                 return True
 
         window.set_default_size(*window.get_size())
-        return False
+        self._application.quit()
+        return True
 
-    def _destroy(self, window):
+    def _destroy(self, _window):
         '''
         Destroy Handler.
 
         The Destroy Handler is invoked by requesting an exit of the program.
-        Or by the Delete Handler returning False.
+        Or by the Delete Handler returning False from a deletion event.
 
-        :param window: Window object
-        :type window: :class:`Gtk.Window`
+        At this point many of the internal objects may have already been
+        destroyed, so this is may be a chance to let background threads,
+        etcetera to be notified to cleanup.
+
+        :param _window: Window object, Unused
+        :type _window: :class:`Gtk.Window`
         '''
-        width, height = window.get_size()
-
-        # maximized = window.maximize_initially
-        maximized = window.is_maximized()
-        if maximized:
-            self._config.set("state", "main_maximized", maximized)
-        if not maximized:
-            self._config.set("state", "main_size_x", str(width))
-            self._config.set("state", "main_size_y", str(height))
-
-        self._application.quit()
+        self.logger.info("_destroy handler called.")
+        print("mainwindow: _destroy handler")
 
     def _activate_save_and_quit(self, _button):
         '''
@@ -181,8 +184,10 @@ class MainWindow(MainWindowElement):
         :param _button: Signaled Widget, unused
         :type _button: :class:`Gtk.ImageMenuItem`
         '''
-        self._window.set_default_size(*self._window.get_size())
-        self._window.destroy()
+        width, height = self._window.get_size()
+        self._window.set_default_size(width, height)
+        # Use delete handler to start the shutdown.
+        self._delete(self._window, None)
 
     def _activate_about(self, _button):
         '''
@@ -365,30 +370,37 @@ class MainWindow(MainWindowElement):
     def _connect_menu_items(self):
 
         menu_quit = self._wtree.get_object("main_menu_quit")
+        add_menu_accel_theme_image(menu_quit, "application-exit",
+                                   _("Quit"), "Q",
+                                   Gdk.ModifierType.CONTROL_MASK)
         menu_quit.connect("activate", self._activate_save_and_quit)
 
         about = self._wtree.get_object("main_menu_about")
+        add_menu_theme_image(about, "help-about", _("About"))
         about.connect("activate", self._activate_about)
 
         debug = self._wtree.get_object("main_menu_debuglog")
         debug.connect("activate", self._activate_debug)
 
         menu_prefs = self._wtree.get_object("main_menu_prefs")
+        add_menu_accel_theme_image(menu_prefs, "preferences-system",
+                                   _("Preferences"), "P",
+                                   Gdk.ModifierType.MOD1_MASK)
         menu_prefs.connect("activate", self._activate_prefs)
 
         menu_map = self._wtree.get_object("main_menu_map")
-        img = Gtk.Image()
-        img.set_from_file("images/map.png")
-        menu_map.set_image(img)
+        add_menu_accel_file_image(menu_map, "images/map.png",
+                                  _("Map"), "M",
+                                  Gdk.ModifierType.CONTROL_MASK)
         menu_map.connect("activate", self._activate_map)
 
         menu_templates = self._wtree.get_object("main_menu_msgtemplates")
         menu_templates.connect("activate", self._activate_message_templates)
 
         ping = self._wtree.get_object("main_menu_ping")
-        img = Gtk.Image()
-        img.set_from_file("images/event_ping.png")
-        ping.set_image(img)
+        add_menu_accel_file_image(ping, "images/event_ping.png",
+                                  _("Ping Station"), "P",
+                                  Gdk.ModifierType.CONTROL_MASK)
         ping.connect("activate", self._activate_ping)
 
         conn = self._wtree.get_object("main_menu_conninet")
@@ -404,9 +416,11 @@ class MainWindow(MainWindowElement):
         sspw.connect("activate", self._activate_station_pane, pane)
 
         menu_dq = self._wtree.get_object("main_menu_dq")
+        add_menu_theme_image(menu_dq, "dialog-question", _("Send D*Query"))
         menu_dq.connect("activate", self._activate_dq)
 
         proxy = self._wtree.get_object("main_menu_proxy")
+        add_menu_theme_image(proxy, "network-workgroup", _("Network Proxy"))
         proxy.connect("activate", self._activate_proxy)
 
     def _page_name(self, index=None):

--- a/d_rats/mainwindow.py
+++ b/d_rats/mainwindow.py
@@ -30,7 +30,6 @@ import subprocess
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import GLib
 

--- a/d_rats/menu_helpers.py
+++ b/d_rats/menu_helpers.py
@@ -20,12 +20,14 @@
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gdk
 from gi.repository import Gtk
 
+# The glade editor used to create the mainwindow can not add icons to the
+# Gtk.MenuItem widgets it defines now that Gtk.ImageMenuItem is deprecated.
+# These functions patch the Gtk.MenuItem to be able to use a PNG image file
+# or a "themed" icon that replaces the deprecated stock icons.
 
-def _add_menu_accel_image(menu_item, menu_icon, label_text,
-                         accel_key_char, accel_mods):
+def _add_menu_accel_image(menu_item, menu_icon, label_text):
     '''
     Add Menu with Accelerator and Theme Image.
 
@@ -35,28 +37,19 @@ def _add_menu_accel_image(menu_item, menu_icon, label_text,
     :type icon_name: :class:`Gtk.Image`
     :param label_text: Text for label
     :type label_text: str
-    :param accel_key_char: Accelerator Key character, Default None
-    :type accel_key_char: str
-    :param accel_mods: Modifiers for key
-    :type accel_mods: :class:`Gdk.ModifierType`
     '''
-    accel_key = Gdk.unicode_to_keyval(ord(accel_key_char))
     menu_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
     menu_box.add(menu_icon)
     label = Gtk.AccelLabel.new(label_text)
-    accel_group = Gtk.AccelGroup.new()
+    label.set_use_underline(True)
     label.set_xalign(0.0)
-    menu_item.add_accelerator("activate", accel_group,
-                              accel_key,
-                              accel_mods,
-                              Gtk.AccelFlags.VISIBLE)
-    menu_box.pack_end(label, True, True, 0)
     label.set_accel_widget(menu_item)
+    menu_box.pack_end(label, True, True, 0)
     menu_item.add(menu_box)
     menu_item.show_all()
 
-def add_menu_accel_theme_image(menu_item, icon_name, label_text,
-                               accel_key_char, accel_mods):
+
+def add_menu_accel_theme_image(menu_item, icon_name, label_text):
     '''
     Add Menu with Accelerator and Theme Image.
 
@@ -66,18 +59,12 @@ def add_menu_accel_theme_image(menu_item, icon_name, label_text,
     :type icon_name: str
     :param label_text: Text for label
     :type label_text: str
-    :param accel_key_char: Accelerator Key character, Default None
-    :type accel_key_char: str
-    :param accel_mods: Modifiers for key
-    :type accel_mods: :class:`Gdk.ModifierType`
     '''
     menu_icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-    _add_menu_accel_image(menu_item, menu_icon, label_text,
-                          accel_key_char, accel_mods)
+    _add_menu_accel_image(menu_item, menu_icon, label_text)
 
 
-def add_menu_accel_file_image(menu_item, icon_file, label_text,
-                              accel_key_char, accel_mods):
+def add_menu_accel_file_image(menu_item, icon_file, label_text):
     '''
     Add Menu with Accelerator and Theme Image.
 
@@ -87,20 +74,33 @@ def add_menu_accel_file_image(menu_item, icon_file, label_text,
     :type icon_name: str
     :param label_text: Text for label
     :type label_text: str
-    :param accel_key_char: Accelerator Key character, Default None
-    :type accel_key_char: str
-    :param accel_mods: Modifiers for key
-    :type accel_mods: :class:`Gdk.ModifierType`
     '''
     image = Gtk.Image()
     image.set_from_file(icon_file)
-    _add_menu_accel_image(menu_item, image, label_text,
-                          accel_key_char, accel_mods)
+    _add_menu_accel_image(menu_item, image, label_text)
 
 
-def add_menu_theme_image(menu_item, icon_name, label_text):
+def _add_menu_image(menu_item, menu_icon, label_text):
     '''
-    Add Menu with Theme Image.
+    Add Menu with Icon Image.
+
+    :param menu_item: Menu item object
+    :type menu_item: :class:`Gtk.MenuItem`
+    :param label_text: Text for label
+    :type label_text: str
+    '''
+    menu_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
+    menu_box.add(menu_icon)
+    label = Gtk.Label.new(label_text)
+    label.set_xalign(0.0)
+    menu_box.add(label)
+    menu_item.add(menu_box)
+    menu_item.show_all()
+
+
+def add_menu_file_image(menu_item, icon_name, label_text):
+    '''
+    Add Menu with file Image.
 
     :param menu_item: Menu item object
     :type menu_item: :class:`Gtk.MenuItem`
@@ -109,11 +109,20 @@ def add_menu_theme_image(menu_item, icon_name, label_text):
     :param label_text: Text for label
     :type label_text: str
     '''
-    menu_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
     menu_icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-    menu_box.add(menu_icon)
-    label = Gtk.Label.new(label_text)
-    label.set_xalign(0.0)
-    menu_box.add(label)
-    menu_item.add(menu_box)
-    menu_item.show_all()
+    _add_menu_image(menu_item, menu_icon, label_text)
+
+
+def add_menu_theme_image(menu_item, icon_name, label_text):
+    '''
+    Add Menu with Theme Image.
+
+    :param menu_item: Menu item object
+    :type menu_item: :class:`Gtk.MenuItem`
+    :param icon_name: File with icon
+    :type icon_name: str
+    :param label_text: Text for label
+    :type label_text: str
+    '''
+    menu_icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
+    _add_menu_image(menu_item, menu_icon, label_text)

--- a/d_rats/menu_helpers.py
+++ b/d_rats/menu_helpers.py
@@ -1,0 +1,119 @@
+'''Menu Helpers.'''
+#
+# Copyright 2022 John Malmberg <wb8tyw@gmail.com>
+# Portions derived from works:
+# Copyright 2009 Dan Smith <dsmith@danplanet.com>
+# review 2019 Maurizio Andreotti  <iz2lxi@yahoo.it>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk
+from gi.repository import Gtk
+
+
+def _add_menu_accel_image(menu_item, menu_icon, label_text,
+                         accel_key_char, accel_mods):
+    '''
+    Add Menu with Accelerator and Theme Image.
+
+    :param menu_item: Menu item object
+    :type menu_item: :class:`Gtk.MenuItem`
+    :param icon_name: Icon image
+    :type icon_name: :class:`Gtk.Image`
+    :param label_text: Text for label
+    :type label_text: str
+    :param accel_key_char: Accelerator Key character, Default None
+    :type accel_key_char: str
+    :param accel_mods: Modifiers for key
+    :type accel_mods: :class:`Gdk.ModifierType`
+    '''
+    accel_key = Gdk.unicode_to_keyval(ord(accel_key_char))
+    menu_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
+    menu_box.add(menu_icon)
+    label = Gtk.AccelLabel.new(label_text)
+    accel_group = Gtk.AccelGroup.new()
+    label.set_xalign(0.0)
+    menu_item.add_accelerator("activate", accel_group,
+                              accel_key,
+                              accel_mods,
+                              Gtk.AccelFlags.VISIBLE)
+    menu_box.pack_end(label, True, True, 0)
+    label.set_accel_widget(menu_item)
+    menu_item.add(menu_box)
+    menu_item.show_all()
+
+def add_menu_accel_theme_image(menu_item, icon_name, label_text,
+                               accel_key_char, accel_mods):
+    '''
+    Add Menu with Accelerator and Theme Image.
+
+    :param menu_item: Menu item object
+    :type menu_item: :class:`Gtk.MenuItem`
+    :param icon_name: Named Icon
+    :type icon_name: str
+    :param label_text: Text for label
+    :type label_text: str
+    :param accel_key_char: Accelerator Key character, Default None
+    :type accel_key_char: str
+    :param accel_mods: Modifiers for key
+    :type accel_mods: :class:`Gdk.ModifierType`
+    '''
+    menu_icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
+    _add_menu_accel_image(menu_item, menu_icon, label_text,
+                          accel_key_char, accel_mods)
+
+
+def add_menu_accel_file_image(menu_item, icon_file, label_text,
+                              accel_key_char, accel_mods):
+    '''
+    Add Menu with Accelerator and Theme Image.
+
+    :param menu_item: Menu item object
+    :type menu_item: :class:`Gtk.MenuItem`
+    :param icon_name: File with icon
+    :type icon_name: str
+    :param label_text: Text for label
+    :type label_text: str
+    :param accel_key_char: Accelerator Key character, Default None
+    :type accel_key_char: str
+    :param accel_mods: Modifiers for key
+    :type accel_mods: :class:`Gdk.ModifierType`
+    '''
+    image = Gtk.Image()
+    image.set_from_file(icon_file)
+    _add_menu_accel_image(menu_item, image, label_text,
+                          accel_key_char, accel_mods)
+
+
+def add_menu_theme_image(menu_item, icon_name, label_text):
+    '''
+    Add Menu with Theme Image.
+
+    :param menu_item: Menu item object
+    :type menu_item: :class:`Gtk.MenuItem`
+    :param icon_name: Named Icon
+    :type icon_name: str
+    :param label_text: Text for label
+    :type label_text: str
+    '''
+    menu_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
+    menu_icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
+    menu_box.add(menu_icon)
+    label = Gtk.Label.new(label_text)
+    label.set_xalign(0.0)
+    menu_box.add(label)
+    menu_item.add(menu_box)
+    menu_item.show_all()

--- a/d_rats/ui/main_chat.py
+++ b/d_rats/ui/main_chat.py
@@ -575,9 +575,7 @@ class ChatTab(MainWindowTab):
         bcast.connect("activate", self._bcast_file, dest)
 
         clear = self._wtree.get_object("main_menu_clear")
-        add_menu_accel_theme_image(clear, "edit-clear",
-                                   _("Clear"), "L",
-                                   Gdk.ModifierType.CONTROL_MASK)
+        add_menu_accel_theme_image(clear, "edit-clear", _("Clear"))
         clear.connect("activate", self._clear)
 
         try:

--- a/d_rats/ui/main_chat.py
+++ b/d_rats/ui/main_chat.py
@@ -40,6 +40,7 @@ from gi.repository import GLib
 from d_rats.ui.main_common import MainWindowElement, MainWindowTab
 from d_rats.ui.main_common import ask_for_confirmation, display_error, \
     set_toolbar_buttons
+from d_rats.menu_helpers import add_menu_accel_theme_image
 from d_rats import inputdialog, utils
 from d_rats import qst
 from d_rats import signals
@@ -574,6 +575,9 @@ class ChatTab(MainWindowTab):
         bcast.connect("activate", self._bcast_file, dest)
 
         clear = self._wtree.get_object("main_menu_clear")
+        add_menu_accel_theme_image(clear, "edit-clear",
+                                   _("Clear"), "L",
+                                   Gdk.ModifierType.CONTROL_MASK)
         clear.connect("activate", self._clear)
 
         try:

--- a/d_rats/ui/message_popup_model.py
+++ b/d_rats/ui/message_popup_model.py
@@ -46,8 +46,8 @@ class MessagePopupModel(Gio.Menu):
     BASE_FOLDERS = [_("Inbox"), _("Outbox"), _("Sent"),
                     _("Trash"), _("Drafts")]
 
-    MENU_ACTIONS = [("delete", _("Delete"), "chat-delfilter.png"),
-                    ("create", _("Create"), "chat-addfilter.png"),
+    MENU_ACTIONS = [("delete", _("Delete"), "edit-delete"),
+                    ("create", _("Create"), "list-add"),
                     ("rename", _("Rename"), None)]
 
     MENU_DELETE_ACTIONS = ["delete", "rename"]
@@ -65,20 +65,17 @@ class MessagePopupModel(Gio.Menu):
         # The actual popup menu has to be in a section.
         menu_popup = Gio.Menu()
 
-        for action_name, label, _icon_file, in self.MENU_ACTIONS:
+        for action_name, label, _icon_name, in self.MENU_ACTIONS:
             # The action name needs a "win." prefix
             menu_item = Gio.MenuItem.new(label, "win.%s" % action_name)
             menu_popup.append_item(menu_item)
             action = Gio.SimpleAction(name=action_name,
                                       parameter_type=None,
                                       enabled=True)
-            # This does not work, the icon does not display.
-            # if _icon_file:
-            #    icon_path = widget.config.ship_obj_fn(
-            #        os.path.join("images", icon_file))
-            #    gio_file = Gio.File.new_for_path(icon_path)
-            #    file_icon = Gio.FileIcon.new(gio_file)
-            #    menu_item.set_icon(file_icon)
+            # This is not working
+            # if icon_name:
+            #    icon = Gio.ThemedIcon.new(icon_name)
+            #    menu_item.set_icon(icon)
             widget.window.add_action(action)
             action.connect('activate', widget.popup_menu_handler)
             self.actions[action_name] = action

--- a/d_rats/ui/station_popup_model.py
+++ b/d_rats/ui/station_popup_model.py
@@ -47,14 +47,14 @@ class StationPopupModel(Gio.Menu):
                      ("conntest", _("Test Connectivity"), None),
                      ("reqpos", _("Request Position"), None),
                      ("sendfile", _("Send file"), None),
-                     ("version", _("Get version"), None),
+                     ("version", _("Get version"), "help-about"),
                      ("mcheck", _("Request mail check"), None),
                      ("qrz", _("Check on Qrz.com"), None)]
 
-    MENU_ACTIONS2 = [("remove", _("Remove"), None),
-                     ("reset", _("Reset"), None)]
+    MENU_ACTIONS2 = [("remove", _("Remove"), "edit-delete"),
+                     ("reset", _("Reset"), "go-jump")]
 
-    MENU_ACTIONS3 = [("clearall", _("Clear All"), None),
+    MENU_ACTIONS3 = [("clearall", _("Clear All"), "edit-clear"),
                      ("pingall", _("Ping All Stations"), None),
                      ("reqposall", _("Request all positions"), None)]
 
@@ -80,20 +80,17 @@ class StationPopupModel(Gio.Menu):
         '''
         menu_popup = Gio.Menu()
 
-        for action_name, label, _icon_file, in section:
+        for action_name, label, _icon_name, in section:
             # The action name needs a "win." prefix
             menu_item = Gio.MenuItem.new(label, "win.%s" % action_name)
             menu_popup.append_item(menu_item)
             action = Gio.SimpleAction(name=action_name,
                                       parameter_type=None,
                                       enabled=True)
-            # This does not work, the icon does not display.
-            # if _icon_file:
-            #    icon_path = widget.config.ship_obj_fn(
-            #        os.path.join("images", icon_file))
-            #    gio_file = Gio.File.new_for_path(icon_path)
-            #    file_icon = Gio.FileIcon.new(gio_file)
-            #    menu_item.set_icon(file_icon)
+            # This still is not working
+            # if icon_name:
+            #    icon = Gio.ThemedIcon.new(icon_name)
+            #    menu_item.set_icon(icon)
             self._widget.window.add_action(action)
             action.connect('activate', self._widget.popup_menu_handler)
             self.actions[action_name] = action

--- a/docs/source/d_rats.rst
+++ b/docs/source/d_rats.rst
@@ -197,6 +197,14 @@ d\_rats.map\_sources module
     :undoc-members:
     :show-inheritance:
 
+d\_rats.menu\_helpers module
+----------------------------
+
+.. automodule:: d_rats.menu_helpers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 d\_rats.miscwidgets module
 --------------------------
 

--- a/ui/mainwindow.glade
+++ b/ui/mainwindow.glade
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.8"/>
+  <requires lib="gtk+" version="3.11"/>
   <object class="GtkDialog" id="dquery_dialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="type_hint">normal</property>
-    <child>
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
@@ -22,11 +19,10 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button3">
-                <property name="label">gtk-ok</property>
+                <property name="label">OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -36,11 +32,10 @@
             </child>
             <child>
               <object class="GtkButton" id="button4">
-                <property name="label">gtk-cancel</property>
+                <property name="label">Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -101,8 +96,6 @@
                   <object class="GtkLabel" id="label3">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">10</property>
-                    <property name="margin_right">10</property>
                     <property name="label" translatable="yes">Command:</property>
                   </object>
                   <packing>
@@ -173,9 +166,6 @@
     <property name="default_width">640</property>
     <property name="default_height">480</property>
     <child>
-      <placeholder/>
-    </child>
-    <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
@@ -204,21 +194,19 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkImageMenuItem" id="main_menu_dq">
-                                <property name="label">gtk-dialog-question</property>
+                              <object class="GtkMenuItem" id="main_menu_dq">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_stock">True</property>
+                                <!--property name="label" translatable="yes">Send D*Query</property-->
+                                <!--property name="use_underline">True</property-->
                               </object>
                             </child>
                             <child>
-                              <object class="GtkImageMenuItem" id="main_menu_proxy">
-                                <property name="label">gtk-network</property>
+                              <object class="GtkMenuItem" id="main_menu_proxy">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_stock">True</property>
+                                <!--property name="label" translatable="yes">Network Proxy</property-->
+                                <!--property name="use_underline">True</property-->
                               </object>
                             </child>
                           </object>
@@ -226,59 +214,53 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_bcast">
-                        <property name="label">Broadcast Text File</property>
+                      <object class="GtkMenuItem" id="main_menu_bcast">
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Broadcast Text File</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="b" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_importmsg">
-                        <property name="label">Import Message</property>
+                      <object class="GtkMenuItem" id="main_menu_importmsg">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Import Message</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_exportmsg">
-                        <property name="label">Export Message</property>
+                      <object class="GtkMenuItem" id="main_menu_exportmsg">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Export Message</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_msgtemplates">
-                        <property name="label">Message Templates</property>
+                      <object class="GtkMenuItem" id="main_menu_msgtemplates">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Message Templates</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_ping">
-                        <property name="label">Ping Station</property>
+                      <object class="GtkMenuItem" id="main_menu_ping">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
-                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <!--property name="label" translatable="yes">Ping Station</property-->
+                        <!--property name="use_underline">True</property-->
+                        <!--accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_prefs">
-                        <property name="label">gtk-preferences</property>
+                      <object class="GtkMenuItem" id="main_menu_prefs">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <accelerator key="p" signal="activate" modifiers="GDK_MOD1_MASK"/>
+                        <!--property name="label" translatable="yes">Preferences</property-->
+                        <!--property name="use_underline">True</property-->
+                        <!--accelerator key="p" signal="activate" modifiers="GDK_MOD1_MASK"/-->
                       </object>
                     </child>
                     <child>
@@ -296,14 +278,13 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_quit">
-                        <property name="label">gtk-quit</property>
+                      <object class="GtkMenuItem" id="main_menu_quit">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
+                        <!--property name="label" translatable="yes">Quit</property-->
+                        <!--property name="use_underline">True</property-->
                         <signal name="activate" handler="on_quit1_activate" swapped="no"/>
-                        <accelerator key="q" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <!--accelerator key="q" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
                       </object>
                     </child>
                   </object>
@@ -319,42 +300,38 @@
                   <object class="GtkMenu" id="menu2">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="cut1">
-                        <property name="label">gtk-cut</property>
+                      <object class="GtkMenuItem" id="cut1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Cut</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_cut1_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="copy1">
-                        <property name="label">gtk-copy</property>
+                      <object class="GtkMenuItem" id="copy1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label">Copy</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_copy1_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="paste1">
-                        <property name="label">gtk-paste</property>
+                      <object class="GtkMenuItem" id="paste1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Paste</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_paste1_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="delete1">
-                        <property name="label">gtk-delete</property>
+                      <object class="GtkMenuItem" id="delete1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Delete</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_delete1_activate" swapped="no"/>
                       </object>
                     </child>
@@ -381,46 +358,41 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_addfilter">
-                        <property name="label">Add filter</property>
+                      <object class="GtkMenuItem" id="main_menu_addfilter">
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Add filter</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_delfilter">
-                        <property name="label">Delete Filter</property>
+                      <object class="GtkMenuItem" id="main_menu_delfilter">
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Delete Filter</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_clear">
-                        <property name="label">gtk-clear</property>
+                      <object class="GtkMenuItem" id="main_menu_clear">
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                        <accelerator key="L" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <!--property name="label" translatable="yes">Clear</property-->
+                        <!--property name="use_underline">True</property-->
+                        <!--accelerator key="L" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_viewlog">
-                        <property name="label">Log</property>
+                      <object class="GtkMenuItem" id="main_menu_viewlog">
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Log</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_map">
-                        <property name="label">Map</property>
+                      <object class="GtkMenuItem" id="main_menu_map">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
-                        <accelerator key="m" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <!--property name="label" translatable="yes">Map</property-->
+                        <!--property name="use_underline">True</property-->
+                        <!--accelerator key="m" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
                       </object>
                     </child>
                   </object>
@@ -437,21 +409,19 @@
                   <object class="GtkMenu" id="menu4">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_debuglog">
-                        <property name="label">Show debug log</property>
+                      <object class="GtkMenuItem" id="main_menu_debuglog">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Show debug log</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">False</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="main_menu_about">
-                        <property name="label">gtk-about</property>
+                      <object class="GtkMenuItem" id="main_menu_about">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
+                        <!--property name="label" translatable="yes">About</property-->
+                        <!--property name="use_underline">True</property-->
                       </object>
                     </child>
                   </object>
@@ -534,7 +504,6 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="headers_clickable">False</property>
-                                    <property name="rules_hint">True</property>
                                     <child internal-child="selection">
                                       <object class="GtkTreeSelection"/>
                                     </child>
@@ -691,11 +660,10 @@
                                     <property name="layout_style">center</property>
                                     <child>
                                       <object class="GtkButton" id="chat_qm_add">
-                                        <property name="label">gtk-add</property>
+                                        <property name="label">Add</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_stock">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -705,11 +673,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="chat_qm_remove">
-                                        <property name="label">gtk-remove</property>
+                                        <property name="label">Remove</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_stock">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -779,11 +746,10 @@
                                     <property name="layout_style">end</property>
                                     <child>
                                       <object class="GtkButton" id="chat_qst_add">
-                                        <property name="label">gtk-add</property>
+                                        <property name="label">Add</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_stock">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -793,11 +759,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="chat_qst_edit">
-                                        <property name="label">gtk-edit</property>
+                                        <property name="label">Edit</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_stock">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -807,11 +772,10 @@
                                     </child>
                                     <child>
                                       <object class="GtkButton" id="chat_qst_remove">
-                                        <property name="label">gtk-remove</property>
+                                        <property name="label">Remove</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_stock">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -963,7 +927,8 @@
                                     <property name="width_request">16</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="stock">gtk-missing-image</property>
+                                    <property name="icon_name">image-missing</property>
+                                    <property name="use_fallback">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1163,7 +1128,6 @@
                               <object class="GtkTreeView" id="event_list">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="rules_hint">True</property>
                                 <child internal-child="selection">
                                   <object class="GtkTreeSelection"/>
                                 </child>
@@ -1228,7 +1192,6 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="headers_visible">False</property>
-                            <property name="rules_hint">True</property>
                             <child internal-child="selection">
                               <object class="GtkTreeSelection"/>
                             </child>
@@ -1353,9 +1316,6 @@
     <property name="title" translatable="yes">Edit Map Source</property>
     <property name="window_position">center-on-parent</property>
     <property name="type_hint">dialog</property>
-    <child>
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -1368,15 +1328,11 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <placeholder/>
-            </child>
-            <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-close</property>
+                <property name="label">Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -1422,18 +1378,12 @@
                     <property name="top_attach">0</property>
                   </packing>
                 </child>
-                <child>
-                  <placeholder/>
-                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
-            </child>
-            <child>
-              <placeholder/>
             </child>
           </object>
           <packing>
@@ -1456,9 +1406,6 @@
     <property name="title" translatable="yes">Edit Map Sources</property>
     <property name="window_position">center-on-parent</property>
     <property name="type_hint">dialog</property>
-    <child>
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
@@ -1471,15 +1418,11 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <placeholder/>
-            </child>
-            <child>
               <object class="GtkButton" id="button2">
-                <property name="label">gtk-close</property>
+                <property name="label">Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -1526,16 +1469,12 @@
                 <property name="can_focus">False</property>
                 <property name="spacing">4</property>
                 <child>
-                  <placeholder/>
-                </child>
-                <child>
                   <object class="GtkButton" id="srcs_add">
-                    <property name="label">gtk-add</property>
+                    <property name="label">Add</property>
                     <property name="width_request">75</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1545,12 +1484,11 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="srcs_edit">
-                    <property name="label">gtk-edit</property>
+                    <property name="label">Edit</property>
                     <property name="width_request">75</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1560,12 +1498,11 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="srcs_delete">
-                    <property name="label">gtk-delete</property>
+                    <property name="label">Delete</property>
                     <property name="width_request">75</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/ui/mainwindow.glade
+++ b/ui/mainwindow.glade
@@ -251,7 +251,7 @@
                         <property name="can_focus">False</property>
                         <!--property name="label" translatable="yes">Ping Station</property-->
                         <!--property name="use_underline">True</property-->
-                        <!--accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
+                        <accelerator key="p" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -260,7 +260,7 @@
                         <property name="can_focus">False</property>
                         <!--property name="label" translatable="yes">Preferences</property-->
                         <!--property name="use_underline">True</property-->
-                        <!--accelerator key="p" signal="activate" modifiers="GDK_MOD1_MASK"/-->
+                        <accelerator key="p" signal="activate" modifiers="GDK_MOD1_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -284,7 +284,7 @@
                         <!--property name="label" translatable="yes">Quit</property-->
                         <!--property name="use_underline">True</property-->
                         <signal name="activate" handler="on_quit1_activate" swapped="no"/>
-                        <!--accelerator key="q" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
+                        <accelerator key="q" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                   </object>
@@ -376,7 +376,7 @@
                         <property name="can_focus">False</property>
                         <!--property name="label" translatable="yes">Clear</property-->
                         <!--property name="use_underline">True</property-->
-                        <!--accelerator key="L" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
+                        <accelerator key="L" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -392,7 +392,7 @@
                         <property name="can_focus">False</property>
                         <!--property name="label" translatable="yes">Map</property-->
                         <!--property name="use_underline">True</property-->
-                        <!--accelerator key="m" signal="activate" modifiers="GDK_CONTROL_MASK"/-->
+                        <accelerator key="m" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
d_rats/menu_helpers.py:
  New modules for functions to update glade generated
  menu items with Icons.

d_rats/mainwindow.py:
  Fix crash on exit.
  Add themed images to replace stock images.

d_rats/ui/main_chat.py:
  Add themed images to replace stock images.

docs/source/d_rats.rst:
  Add d_rats/menu_helpers.py

ui/mainwindow.glade:
  Replace GtkImageMenuItem with GtkMenuItem.

d_rats/ui/message_popup_model.py:
d_rats/ui/station_popup_model.py:
  Set up to use themed icons.
  Themed icons still are not working.