### PR TITLE
fix(python3): Remove remaining six.moves imports

### DIFF
--- a/d_rats/map_sources.py
+++ b/d_rats/map_sources.py
@@ -28,8 +28,8 @@ import os
 import urllib
 from glob import glob
 from lxml import etree
-from six.moves.configparser import NoSectionError # type: ignore
-from six.moves.configparser import NoOptionError # type: ignore
+from configparser import NoSectionError
+from configparser import NoOptionError
 
 import gi
 gi.require_version("Gtk", "3.0")

--- a/d_rats/miscwidgets.py
+++ b/d_rats/miscwidgets.py
@@ -24,8 +24,6 @@ from __future__ import print_function
 import logging
 import os
 
-from six.moves import range # type:ignore
-
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk

--- a/d_rats/sessions/control.py
+++ b/d_rats/sessions/control.py
@@ -2,7 +2,7 @@
 '''Control'''
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
-# Python3 update Copyright 2021 John Malmberg <wb8tyw@qsl.net>
+# Python3 update Copyright 2021-2022 John Malmberg <wb8tyw@qsl.net>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,8 +22,6 @@ from __future__ import print_function
 
 import logging
 import struct
-
-from six.moves import range # type: ignore
 
 from d_rats.utils import log_exception
 from d_rats.ddt2 import DDT2EncodedFrame

--- a/d_rats/sessions/file.py
+++ b/d_rats/sessions/file.py
@@ -19,12 +19,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-try:
-    # python2
-    from UserDict import UserDict # type: ignore
-except ModuleNotFoundError:
-    # python3
-    from collections import UserDict
 
 import logging
 import struct
@@ -33,7 +27,8 @@ import time
 import zlib
 import sys # python 2 support only
 
-from six.moves import range # type: ignore
+from collections import UserDict
+
 from d_rats.sessions import base, stateful
 
 # This makes pylance happy with out overriding settings
@@ -132,7 +127,7 @@ class FileTransferSession(stateful.StatefulSession):
 
         :param filename: Filename to send
         :type filename: str
-        :returns: True if file tranferred.
+        :returns: True if file transferred.
         :rtype: bool
         '''
         data = self.get_file_data(filename)

--- a/d_rats/sessions/stateful.py
+++ b/d_rats/sessions/stateful.py
@@ -25,8 +25,6 @@ import struct
 import threading
 import time
 
-from six.moves import range # type: ignore
-
 from d_rats import transport
 from d_rats.ddt2 import DDT2EncodedFrame
 from d_rats.sessions import base
@@ -274,7 +272,7 @@ class StatefulSession(base.Session):
 
         # Short circuit to just an ack for outstanding blocks, if
         # we're still waiting for an ack from remote.  Increase the timeout
-        # for the ack by four seconds each time to give some backoff
+        # for the ack by four seconds each time to give some back off
         if self.waiting_for_ack:
             self.logger.info("send_blocks: Didn't get last ack, asking again")
             self.send_reqack(self.waiting_for_ack)
@@ -529,7 +527,7 @@ class StatefulSession(base.Session):
 
         if count is None:
             buffer = self.data.dequeue_all()
-            # BlockQueue.dequeue_all() returns the blocks in popable order,
+            # BlockQueue.dequeue_all() returns the blocks in pop able order,
             # which is newest first
             buffer.reverse()
             empty = bytearray()

--- a/d_rats/ui/main_chat.py
+++ b/d_rats/ui/main_chat.py
@@ -27,7 +27,7 @@ import os
 import time
 import re
 from datetime import datetime
-from six.moves.configparser import NoSectionError # type: ignore
+from configparser import NoSectionError
 
 import gi
 gi.require_version("Gtk", "3.0")

--- a/d_rats/utils.py
+++ b/d_rats/utils.py
@@ -21,15 +21,11 @@ from __future__ import print_function
 
 import logging
 from io import FileIO
-# import re
+
 import os
 import tempfile
 
-# pylance can not deal with imports of six classes
-import six.moves.urllib.request # type: ignore
-import six.moves.urllib.parse # type: ignore
-import six.moves.urllib.error # type: ignore
-from six.moves import range # type: ignore
+import urllib.request
 
 from . import dplatform
 
@@ -269,7 +265,7 @@ def run_or_error(function):
 
     return runner
 
-# possibly deprecated to be replaced by logging moodule.
+# possibly deprecated to be replaced by logging module.
 def print_stack():
     '''Print Stack'''
     import traceback
@@ -391,7 +387,7 @@ class NetFile(FileIO):
                 tmpf.close()
 
                 self.logger.info("init: Retrieving %s -> %s", uri, self.__fn)
-                six.moves.urllib.request.urlretrieve(uri, self.__fn)
+                urllib.request.urlretrieve(uri, self.__fn)
                 break
 
         super(NetFile, self).__init__(self, self.__fn, mode, buffering)


### PR DESCRIPTION
d_rats/map_sources.py:
d_rats/miscwidgets.py:
d_rats/sessions/control.py:
d_rats/sessions/file.py:
d_rats/sessions/stateful.py:
d_rats/ui/main_chat.py:
d_rats/utils.py:
  Remove six.moves imports and references.