### PR TITLE
fix(dplatform): Fix system data paths

### DIFF
--- a/d-rats.py
+++ b/d-rats.py
@@ -205,7 +205,7 @@ def main():
     if args.config:
         MODULE_LOGGER.info("main: re-config option found -- Reconfigure D-rats")
         MODULE_LOGGER.info("main: args.config = %s", args.config)
-        platform.set_base_dir(args.config)
+        platform.set_config_dir(args.config)
 
     # import the D-Rats main application
     from d_rats import mainapp


### PR DESCRIPTION
d-rats.py:
  Set the platform_config_dir, it is not a base dir.

d_rats/dplatform.py:
  Fix the system data path to use the standard locations
  instead of a hardcoded one that does not work for
  installing from pip into a virtual environment.
  Change set_base_dir to set_config_dir to remove confusion.
  Start deprecation of get_source method.
  Add method to get the constant d-rats data.