### PR TITLE
fix(packaging): New packaging method

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,10 +4,15 @@ include forms/*.xml
 include forms/*.xsl
 include images/*
 include locale/*/LC_MESSAGES/D-RATS.mo
-include ui/*.glade
+include ui/addport.glade
+include ui/mainwindow.glade
 include d_rats/version.py
+include d-rats.py
+include d-rats_repeater.py
 include share/d-rats2.xpm
 include d-rats2.ico
 include libexec/lzhuf
 include MANIFEST.in
 include COPYING
+include changelog.gz
+include NEWS.rst.gz

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,0 +1,6 @@
+For the python 2 version see the changelog file.
+
+The ticket numbers in this file for the Python 3 port are from
+https://github.com/wb8tyw/D-Rats/issues
+
+.. towncrier release notes start

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 
 Dan Smith (KK7DS)
 
-### Maintainer
+### Maintainers
 
 Maurizio Andreotti IZ2LXI - Stable branch
 <https://github.com/maurizioandreotti/D-Rats>
@@ -34,10 +34,12 @@ John E. Malmberg WB8TYW - Python3/Experimental port
 
 This version of D-Rats is an experimental fork version of the D-Rats 0.3.3.
 originally developed and Copyrighted by 2008 Dan Smith <dsmith@danplanet.com>
-and later reviewed in 2015, 2019 and 2020 by me, Maurizio Andreotti
+and later reviewed in 2015, 2019 and 2020 by me, Maurizio Andreotti.
+
+Python3 conversion Copyright 2021-2022 John Malmberg.
 
 This is likely to be changing a lot as a lot of functionality has not been
-tested and some functionality does not work.
+tested and some functionality may not work.
 
 See: <https://github.com/wb8tyw/D-Rats/wiki/Tests-and-issues-found>
 
@@ -48,6 +50,8 @@ Luckily there is no obligation for anybody to use it, in particular if you are
 happy with the one from Dan.
 
 If this works for you I am happy, If it doesn't ...
+
+### A note from Maurizio Andreotti
 
 ***Note for awareness and understanding***
 
@@ -61,13 +65,13 @@ itself changed multiple times, and each of us has a different footprint of
 applications installed, making each execution situation different. So there is
 no promise from me that it will work on your PC.
 
-Recompiling it (even unchanged) nowdays for Windows has been challenging and
+Recompiling it (even unchanged) now days for Windows has been challenging and
 implied going back to windows XP to ensure compatibility and a lot of hours of
 tests and investigation, I am glad it works for me and some others.
 
 It was difficult to get it work on my PC (Win10 and XP) with full access to
 logs and realtime control of what happens (e.g. clicking on some d-rats
-button, and looking d-rats behaviour result and logs to sort out thinkgs).
+button, and looking d-rats behavior result and logs to sort out things).
 
 If in your case it does not work, that is an unhappy case which I feel it will
 continue not working until some magic happens (in particular if there is not
@@ -84,65 +88,45 @@ things.
 
 ## Supported systems
 
-This is in flux at the moment for this fork.
-Currently this is only being tested on Anti-X linux, which can run both the
-experimental version and the stable version.
+Currently this experimental fork is only being tested by John Malmberg
+on Anti-X linux, which can run both the experimental version and the stable version and Msys2 mingw64 on Microsoft Windows which can only run the python3 version.
 
-This version requires GTK-3.
+Anti-X Linux is a Debian based distribution that will run on older systems
+with limited memory.
 
-Only the d-rats_repeater function is currently working under Python3.
+This version requires Python 3.7+ and GTK-3.
 
-Eventually the python2 support will likely be removed from this fork.
+For now support or the pre-built executables has been dropped.
+You will need to install a Python 3 interpreter.
 
-### Older Text
-
-This program ONLY work with older Linux distributions that still include
-Python2, GTK2, etc.
-Support for this program on newer distros is NOT possible until major porting
-work is completed.
-
-On Ms Windows the program works only when compiled on Windows XP 32 bit and
-distributed keeping some of the DLLs related to GDI and Networking of that
-version.
+John Malmberg will not be installing or testing any Python interpreter
+that requires a paid license for commercial work, even if that license allows
+free non-commercial use.  Some Pythons distributions for Microsoft Windows
+have this restriction.
 
 ---
 
 ## Release notes
 
-see change log for stable version:
+See change log for stable version:
 <https://github.com/maurizioandreotti/D-Rats/blob/master/changelog>
+
+See the NEWS.rst file for changes in packages produced from this
+python3 fork.
 
 ---
 
-## FOR MORE INFO HAVE A WALK IN THE WIKI
+## FOR MORE INFO HAVE A WALK IN THE WIKIs
 
 <https://github.com/maurizioandreotti/D-Rats/wiki/D-Rats-Evolution-wiki>
 
----
-
-### READY TO RUN -- EXECUTION ON WINDOWS
-
-To install the new version of D-Rats on Windows download the distrubution
-version (file in .rar format)
-uncompress it in a folder of your choice and just run d-rats.exe
-
-AT THE MOMENT THERE IS A "BUILT VERSION" IN THE RAR FILE, BUT THERE ARE SOME
-KNOWN ISSUES WITH LIBRARIES NOT INCLUDED,  SO IT IS POSSIBLE THAT IT WILL NOT
-WORK ON YOUR SYSTEM. PLEASE REPORT ME THE PROBLEMS YOU HAVE.  YOUR HELP CAN
-BE USEFUL TO SORT THIS OUT.
-
-The windows executable can be downlodaded from here:
-      - <https://iz2lxi.jimdofree.com/>
-
-Note that at runtime the eventual errors are logged into a file located either
-at:
-
-- d-rats.exe location as d-rats.log
-- C:\Users\<username>\AppData\Roaming\D-RATS-EV\debug.log
+<https://github.com/wb8tyw/D-Rats/wiki>
 
 ---
 
-### INSTALL ON LINUX
+## Running, Testing and Building packages
+
+### Installing Python
 
 (contrib & credit Marius Petrescu)
 Quick update by John Malmberg
@@ -153,6 +137,8 @@ The installation steps are quite easy (assuming one has all the needed python
 libs installed):
 
 Debian packages needed for running or development.
+The python2 packages are only needed for running the stable python2 version
+of d-rats.
 
 aspell aspell-en bandit(future) gedit python2 python3 pylint pylint3 glade
 python-gobject python-gtk2 python3-gi python-glade2 python-serial
@@ -160,16 +146,161 @@ python3-serial python-libxml2 python-libxslt1 python3-lxml python-simplejson
 python-feedparser python-flask python-gevent python3-gevent python-socketio
 python3-greenlet python-ipykernel python-gi-cairo python-geopy python-pil
 
-After this, the steps are as follows:
+For msys2, the script msys2_packages.sh will hopefully install all the
+needed packages.  The "dev" parameter is passed to install extra images
+needed for development, or installing directly from a git archive.
 
-cd to your D-Rats source directory
-issue 'python setup.py build'
-issue 'python setup.py install'    (this could require a sudo)
+If the script is updating certain packages, it may need to have the msys2
+windows shutdown after running, and then need to be re-run to complete the
+install.
 
-you can now execute D-Rats from terminal,:
+Repeat running the script until it no longer requests a msys2 restart.
+Normally an msys2 restart or install should not require a reboot of
+Microsoft Windows.
+
+Other Python interpreters should be similar.  If the python distribution does
+not supply all of the packages, then PIP can be used to supply the missing
+packages.  PIP generally should always be used with a python virtual
+environment.
+
+See: <https://github.com/wb8tyw/D-Rats/wiki/Running-d-rats-in-a-venv-environment-and-PIP>
+
+And read the rest of this document for more tips.
+
+### Running directly from the D-rats source
+
+Running directly from the D-rats source is easily done.
+
+You can clone the git repository into a work directory so that you can
+run the latest pre-release, or git allows you to download a compressed
+archive of any commit or pull request.
+
+Before running D-Rats there are two optional tasks if you want everything
+to work.
+
+If you want Winlink support to work, you need to build the lzhuf binary.
+
+- make -C libexec
+
+If you want the internationalization to work, and especially if you want
+to add more languages you have to build the message catalogs.
+
+See <https://github.com/wb8tyw/D-Rats/wiki/Internationalization> for the
+easy steps for building and maintaining the message catalogs.
+
+### Build for INSTALL ON LINUX and MSYS2 and others
+
+This should work for all platforms.
+
+When a pull request is submitted, it should have a file put in the changes
+directory for the tickets that resolves.
+
+Note that we do not do the 'towncrier build' command.  The packaging
+building process will to that.  You can use the 'towncrier build --draft'
+command to see what will be appended to the NEWS.rst file.
+See <https://pypi.org/project/towncrier/>
+
+If you run the 'towncrier build' command by accident, you will need
+revert the local changes that it makes to your checked out git repository.
+
+Normally a git tag wtih a PEP-440 compliant version will be created before
+the python package build procedure is run, and you would check out that
+commit for doing the build.
+
+The current build procedure requires setting up a python venv.
+See: <https://github.com/wb8tyw/D-Rats/wiki/Running-d-rats-in-a-venv-environment-and-PIP>
+
+For msys2, if you have made an update to the msys2 packages, you may need
+to delete and recreate your python venv.
+
+Activate the venv as per the link above.
+
+Change the default to your D-Rats source directory
+
+Install the packages needed for building into the venv.
+issue 'pip install -r requirements.txt'
+
+Microsoft Windows users may need to 'pip install pywin32 into the virtualenv
+depending which python distribution they are using.  It is not needed for
+msys2.
+
+Use 'pip freeze' to see what python modules are currently installed.
+
+You can upgrade PIP with the command given if yoo are getting a message
+about it needing and upgrade.  With the venv activated all changes are
+local to the venv.
+
+If you are using a shared directory for multiple platforms, before
+running the build procedure remove the old lzhuf binary so the setup
+procedure will build the correct binary for the target.
+
+Normally a python package does not include a pre-built binary, and instead
+runs a script to built on a Pip install.  That would add additional software
+to be installed by the end user.
+
+Issue 'python -m build'
+
+The build script will use towncrier to build an updated NEWS.rst file.
+It will modify the checked out git directory with the changes that it did.
+
+If you are just testing the build process, then you need to revert those
+changes from your local git checkout.
+
+For a real release, these changes should be pushed as a followup pull
+request for that branch and merged in.
+
+The build procedure will create a dist directory if it does not exist and
+create what is known as a tarball, and a wheel file.
+
+We do not currently use the wheel file which has an extension of '.whl'.
+
+The tarball has a double extension on it of ".tar.gz".  As compression
+standards evolve, the extension of ".gz" may change to match.
+
+Previously on MS-DOS and other platforms that only supported one dot in a
+filename, the extension of ".tgz" was used instead of ".tar.gz", and that convention is still widely used on those platforms.
+
+Before distributing the tarball, it should be renamed to be indicate the
+platform and architecture in the name.
+
+The built tarball name of 'D-Rats-0.3.10b2.dev301.tar.gz' has these parts:
+
+- Name: 'D-Rats'
+
+- Version: '0.3.10b2.dev301'
+
+- Extension: '.tar.gz'
+
+The platform specific designation is typically put between the version
+and the extension, in the form of '-platform-arch'.
+
+Each Operating System Distribution has conventions on what they use for
+platform and version and these should be followed if known.
+
+So a rename for Msys2 would be 'D-Rats-0.3.10b2.dev301-mingw-w64-x86_64.tar.gz'.
+
+For Linux, it is probably more generic so that
+'D-Rats-0.3.10b2.dev301-linux-x86_64.tar.gz' can be used.
+
+I do not know what the name would be for Mac-OSX, we need some guidance from
+the community.
+
+### Install of a built tarball
+
+To install from a tarball use the command with the path to the tarball.
+The build step above puts the tarball in the dist directory.
+You will have to adjust the tarball name for specific version.
+In the example this is a development version that is 299 commits
+
+For msys2, I had to set my default directory to a different directory
+than the development directory for the pip install to work.
+
+pip install ./dist/D-Rats-0.3.3.10b2.dev300.tar.gz
+
+you can now execute D-Rats from terminal:
 
 > d-rats.py
-> d-rats-terminal
+> d-rats_repeater.py
 
 This should do it. Main scripts are in /usr/local/bin, configuration and logs
 will be found in the user's home directory as .d-rats-ev (a hidden directory).

--- a/changelog
+++ b/changelog
@@ -1,10 +1,12 @@
-20210711 - 0.4.00 pre-release #
+20210711 - 0.3.10b2.dev300 unreleased
+- Future entries will be in NEWS.rst
 - This is experimental use only for development and testing
 - Start of python3 conversion
 - Silencing pylint diagnostics.  Fix issues when practical.
   Had to guess at some variable renaming required to comply with pylint.
 - Add DocStrings - Had to guess at some definitions.
 - Additional debug code has been added.
+
 
 20200529 - 0.3.9 - beta 3
 - added timestamp in repeater log 

--- a/changes/100.bugfix
+++ b/changes/100.bugfix
@@ -1,0 +1,2 @@
+When running D-Rats from source, it no longer requires your
+default directory to be the source directory.

--- a/changes/115.bugfix
+++ b/changes/115.bugfix
@@ -1,0 +1,2 @@
+Clients will attempt to reconnect to internet ratflector when
+they detect a disconnection.

--- a/changes/121.misc
+++ b/changes/121.misc
@@ -1,0 +1,2 @@
+Non-functional out of date version of geopy removed.
+Use of geopy package is now optional.

--- a/changes/124.bugfix
+++ b/changes/124.bugfix
@@ -1,0 +1,10 @@
+Some platform D-RATS program can not exchange files with programs running on
+other plaforms.  D-Rats was incorrectly sending the file size in
+native-endian format instead of network-endian format.
+
+D-RAts is now sending the file size in little-endian format instead of
+network-endian format to be compatible with the majority of existing
+D-rats programs in use.
+
+Users of D-Rats on big-endian platforms need to upgrade to this version
+of d-rats.

--- a/changes/125.misc
+++ b/changes/125.misc
@@ -1,0 +1,1 @@
+The agw.py module internally did not match the actual AGWPE documenation.

--- a/changes/134.feature
+++ b/changes/134.feature
@@ -1,0 +1,1 @@
+Now using 'python -m build' to build python packages.

--- a/changes/135.bugfix
+++ b/changes/135.bugfix
@@ -1,0 +1,2 @@
+The lzhuf program will now build on Mac OSX plaforms and
+probably other plaforms that it did not build on before.

--- a/changes/202.bugfix
+++ b/changes/202.bugfix
@@ -1,0 +1,1 @@
+Serial port warmup timeout in d-rats_repeater is now working.

--- a/changes/204.feature
+++ b/changes/204.feature
@@ -1,0 +1,1 @@
+The d_rats-repeater now supports all the radio types as the D-rats program.

--- a/changes/245.feature
+++ b/changes/245.feature
@@ -1,0 +1,2 @@
+Per current python conventions, towncrier is used for creatng a News.rst
+file that replaces the changelog file.

--- a/changes/246.bugfix
+++ b/changes/246.bugfix
@@ -1,0 +1,3 @@
+D-rats can now be installed in a python virtual enviroment.
+Fixed the paths for where system data is stored and looked for
+to match Python and general conventions.

--- a/changes/247.feature
+++ b/changes/247.feature
@@ -1,0 +1,1 @@
+Add your info here

--- a/changes/254.bugfix
+++ b/changes/254.bugfix
@@ -1,0 +1,1 @@
+Add your info here

--- a/changes/73.bugfix
+++ b/changes/73.bugfix
@@ -1,0 +1,1 @@
+Required attribution use of OpenWeather (TM) data added.

--- a/install.txt
+++ b/install.txt
@@ -11,27 +11,37 @@ GNU General Public License for more details.
 -----------------------
 # Copyright 2008 Dan Smith <dsmith@danplanet.com> 
 # review 2015-2020 Maurizio Andreotti  <iz2lxi@yahoo.it>
+# Python3 conversion Copyright 2020-2022 John Malmberg <wb8tyw@qsl.net>
 -----------------------
 
-Welcome to D-Rats compiled for Windows - tested on XP, and Windows 10
+Welcome to D-Rats compiled for Windows - tested on 7, and Windows 10
+Windows 7 support is being dropped by the third party libraries needed soon.
 
 --------------------------------------
 IF YOU ARE ALREADY A USER OF D-RATS
 
 COMPATIBILITY NOTES
 ** D-RATS 0.3.5 --> 0.3.6** 
-this version share the same configuration file of 0.3.5 - there are no actions to be done 
+This version share the same configuration file of 0.3.5 - there are no actions
+to be done.
 
 ** D-RATS 0.3.4 ** 
-this version, like 0.3.5, need a configuration file which is different from 0.3.4, so please remove or delete it:
+This version, like 0.3.5, need a configuration file which is different from
+0.3.4, so please remove or delete it:
 
-C:\Users\YOUR-USER-NANME\AppData\Roaming\D-RATS-EV\d-rats.config
+C:\Users\YOUR-USER-NAME\AppData\Roaming\D-RATS-EV\d-rats.config
 
 ** D-RATS <= 0.3.3 ** 
-This version will create its own data folder in parallel to the one created by former d-Rats 0.3.3 install, so not to interfere 
+This version will create its own data folder in parallel to the one created
+by former d-Rats 0.3.3 install, so not to interfere.
 
 
 --------------------------------------
 IF YOU ARE A FIRST TIME USER OF D-RATS
 
-To use this version just uncompress it into a folder of your choice and launch d-rats.exe
+D-rats can be run from a copy of the git repository you found it in.
+However you will need to build the message catalogs for internationalization
+to work and lzhuf for winlink support.
+At some point we need some documentation for those steps.
+
+See the file README.md for more details.

--- a/libexec/makefile
+++ b/libexec/makefile
@@ -15,4 +15,4 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	$(RM) $(EXECUTABLE) *.o
+	$(RM) -f $(EXECUTABLE) $(EXECUTABLE).exe *.o

--- a/msys2_packages.sh
+++ b/msys2_packages.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+mingw='mingw-w64-x86_64'
+
+pacman -Syu --noconfirm \
+    "${mingw}-python" \
+    "${mingw}-gtk3" \
+    "${mingw}-gettext" \
+    "${mingw}-python3-gobject" \
+    "${mingw}-aspell" "${mingw}-aspell-en" \
+    "${mingw}-python-pywin32" \
+    "${mingw}-python-lxml" \
+    "${mingw}-python-pyserial" \
+    "${mingw}-python-pillow"
+
+if [[ "$1" == dev* ]]; then
+  # packaging
+  pacman -Syu --noconfirm \
+    "${mingw}-gcc" \
+    "${mingw}-glade" \
+    "${mingw}-make" \
+    "${mingw}-python-pylint" \
+    "${mingw}-python-setuptools" \
+    "${mingw}-python-virtualenv"
+
+    # This should not be needed, but is for now.
+    ln -sf /mingw64/bin/mingw32-make.exe /mingw64/bin/make.exe
+fi

--- a/newsfragments/.gitignore
+++ b/newsfragments/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=40"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "D-Rats"
+description = "A communications tool for D-STAR"
+readme = "README.md"
+requires-python = ">=3.7"
+license = {text = "GPL-3"}
+dynamic = ["version"]
+dependencies = [
+    "lxml",
+    "pycairo",
+    "PyGObject",
+    "pyserial",
+    "Pillow",
+    "geopy",
+    "feedparser"
+]
+
+[tool.towncrier]
+directory = "changes"
+package = 'd_rats.version'
+
+[tool.setuptools]
+packages = ['d_rats', 'd_rats.map', 'd_rats.sessions', 'd_rats.ui' ]
+
+[tool.setuptools.dynamic]
+version = {attr = "d_rats.version.DRATS_PEP440_VERSION"}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,18 @@
+# requirements for d-rats
+# Packages needed for running
+lxml
+pycairo
+PyGObject
+pyserial
+Pillow
+# packages recommended for running
+geopy
+feedparser
+# packages needed for development
+Sphinx
+virtualenv
+pylint
+build
+setuptools
+wheel
+towncrier

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
-[bdist_rpm]
-requires = python-glade2, python-libxml2, python-libxslt1, python-serial
+
+#[bdist_rpm]
+#requires = python-glade2, python-libxml2, python-libxslt1, python-serial

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-'''Python Setup Module.'''
+#!/usr/bin/env python3
+'''Python setup.py.'''
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
 # review 2015-2020 Maurizio Andreotti  <iz2lxi@yahoo.it>
 # Copyright 2022 John. E. Malmberg - Python3 Conversion
@@ -15,199 +16,81 @@
 #
 # You should have received a copy of the GNU General Public License
 
-
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os
-import sys
+from os import system
+from os.path import dirname, exists, join
+from glob import glob
+from setuptools import setup
 
 from d_rats.version import DRATS_VERSION
 
-def win32_build():
-    '''Microsoft Windows Build.'''
-    from distutils.core import setup
-    # pylint: disable=import-error, unused-import
-    import py2exe # type: ignore
-
-    try:
-        # if this doesn't work, try import modulefinder
-        import py2exe.mf as modulefinder # type: ignore
-        import win32com  # type: ignore
-        for path in win32com.__path__[1:]:
-            modulefinder.AddPackagePath("win32com", path)
-        for extra in ["win32com.shell"]: #,"win32com.mapi"
-            __import__(extra)
-            modules = sys.modules[extra]
-            for path in modules.__path__[1:]:
-                modulefinder.AddPackagePath(extra, path)
-    except ImportError:
-        # no build path setup, no worries.
-        pass
-
-    opts = {
-        "py2exe" : {
-            "includes" : "pango,atk,gobject,cairo,pangocairo" \
-                         ",win32gui,win32com,win32com.shell" \
-                         ",email.iterators,email.generator,gio" \
-                         ",simplejson,six,xmlrpclib" \
-                         ",SimpleXMLRPCServer,SocketServer" \
-                         ",BaseHTTPServer",
-            'dll_excludes': [
-                'API-MS-Win-Core-Debug-L1-1-0.dll',
-                'API-MS-Win-Core-DelayLoad-L1-1-0.dll',
-                'API-MS-Win-Core-ErrorHandling-L1-1-0.dll',
-                'API-MS-Win-Core-File-L1-1-0.dll',
-                'API-MS-Win-Core-Handle-L1-1-0.dll',
-                'API-MS-Win-Core-Heap-L1-1-0.dll',
-                'API-MS-Win-Core-Interlocked-L1-1-0.dll',
-                'API-MS-Win-Core-IO-L1-1-0.dll',
-                'API-MS-Win-Core-LibraryLoader-L1-1-0.dll',
-                'API-MS-Win-Core-Localization-L1-1-0.dll',
-                'API-MS-Win-Core-LocalRegistry-L1-1-0.dll',
-                'API-MS-Win-Core-Memory-L1-1-0.dll',
-                'API-MS-Win-Core-Misc-L1-1-0.dll',
-                'API-MS-Win-Core-ProcessEnvironment-L1-1-0.dll',
-                'API-MS-Win-Core-ProcessThreads-L1-1-0.dll',
-                'API-MS-Win-Core-Profile-L1-1-0.dll',
-                'API-MS-Win-Core-String-L1-1-0.dll',
-                'API-MS-Win-Core-Synch-L1-1-0.dll',
-                'API-MS-Win-Core-SysInfo-L1-1-0.dll',
-                'DNSAPI.DLL',
-                'MSIMG32.DLL',
-                'MSWSOCK.dll',
-                'NSI.DLL',
-                'USP10.DLL'
-                ],
-            "compressed" : 1,
-            "optimize" : 2,
-            "bundle_files" : 3,
-            # "skip_archive" : True,
-            # "packages" : ""
-            }
-        }
-
-# Missing modules according to py3exe output
-#
-# 'BeautifulSoup', 'FCNTL', 'Image', 'PIL', 'System', 'System.IO.Ports',
-# 'TERMIOS', '_scproxy', '_speedups', '_sysconfigdata', 'clr',
-# 'django.utils.simplejson', 'django.utils.six.moves.urllib.parse', 'dl',
-# 'email.MIMEBase', 'email.MIMEMultipart', 'email.MIMEText', 'email.Message',
-# 'feedparser', 'gdk', 'importlib.find_loader', 'importlib.reload',
-# 'importlib.util', 'ossaudiodev', 'pytz', 'simplejson._speedups', 'unix',
-# 'urllib.parse', 'glib.GError', 'glib.IOChannel', 'glib.IO_ERR',
-# 'glib.IO_FLAG_APPEND', 'glib.IO_FLAG_GET_MASK', 'glib.IO_FLAG_IS_READABLE',
-# 'glib.IO_FLAG_IS_SEEKABLE', 'glib.IO_FLAG_IS_WRITEABLE',
-# 'glib.IO_FLAG_MASK', 'glib.IO_FLAG_NONBLOCK', 'glib.IO_FLAG_SET_MASK',
-# 'glib.IO_HUP', 'glib.IO_IN', 'glib.IO_NVAL', 'glib.IO_OUT', 'glib.IO_PRI',
-# 'glib.IO_STATUS_AGAIN', 'glib.IO_STATUS_EOF', 'glib.IO_STATUS_ERROR',
-# 'glib.IO_STATUS_NORMAL', 'glib.Idle', 'glib.MainContext',
-# 'glib.MainLoop', 'glib.OPTION_ERROR', 'glib.OPTION_ERROR_BAD_VALUE',
-# 'glib.OPTION_ERROR_FAILED', 'glib.OPTION_ERROR_UNKNOWN_OPTION',
-# 'glib.OPTION_FLAG_FILENAME', 'glib.OPTION_FLAG_HIDDEN',
-# 'glib.OPTION_FLAG_IN_MAIN', 'glib.OPTION_FLAG_NOALIAS',
-# 'glib.OPTION_FLAG_NO_ARG', 'glib.OPTION_FLAG_OPTIONAL_ARG',
-# 'glib.OPTION_FLAG_REVERSE', 'glib.OPTION_REMAINING', 'glib.OptionContext',
-# 'glib.OptionGroup', 'glib.PRIORITY_DEFAULT', 'glib.PRIORITY_DEFAULT_IDLE',
-# 'glib.PRIORITY_HIGH', 'glib.PRIORITY_HIGH_IDLE', 'glib.PRIORITY_LOW',
-# 'glib.Pid', 'glib.PollFD', 'glib.SPAWN_CHILD_INHERITS_STDIN',
-# 'glib.SPAWN_DO_NOT_REAP_CHILD', 'glib.SPAWN_FILE_AND_ARGV_ZERO',
-# 'glib.SPAWN_LEAVE_DESCRIPTORS_OPEN', 'glib.SPAWN_SEARCH_PATH',
-# 'glib.SPAWN_STDERR_TO_DEV_NULL', 'glib.SPAWN_STDOUT_TO_DEV_NULL',
-# 'glib.Source', 'glib.Timeout', 'glib.child_watch_add',
-# 'glib.filename_display_basename', 'glib.filename_display_name',
-# 'glib.filename_from_utf8', 'glib.get_application_name',
-# 'glib.get_current_time', 'glib.get_prgname', 'glib.glib_version',
-# 'glib.idle_add', 'glib.io_add_watch', 'glib.main_context_default',
-# 'glib.main_depth', 'glib.markup_escape_text', 'glib.set_application_name',
-# 'glib.set_prgname', 'glib.source_remove', 'glib.spawn_async',
-# 'glib.timeout_add', 'glib.timeout_add_seconds',
-# 'glib.uri_list_extract_uris', 'gtk.Assistant']
-#
-    setup(
-        windows=[{'script' : "d-rats.py",
-                  'icon_resources': [(0x0004, 'd-rats2.ico')]},
-                 {'script' : 'd-rats_repeater.py'}],
-        # adapt the following line for your system
-        data_files=["C:\\GTK\\bin\\jpeg62.dll"],
-        options=opts)
-
-def macos_build():
-    '''Mac OS Build.'''
-    from setuptools import setup
-    import shutil
-
-    # pylint: disable=invalid-name
-    APP = ['d-rats-%s.py' % DRATS_VERSION]
-    shutil.copy("d-rats", APP[0])
-    # pylint: disable=invalid-name
-    DATA_FILES = [('../Frameworks',
-                   ['/opt/local/lib/libpangox-1.0.0.2203.1.dylib']),
-                  ('../Resources/pango/1.6.0/modules',
-                   ['/opt/local/lib/pango/1.6.0/modules/pango-basic-atsui.so']),
-                  ('../Resources',
-                   ['images', 'ui']),
-                  ]
-    # pylint: disable=invalid-name
-    OPTIONS = {'argv_emulation': True, "includes" : "gtk,atk,pangocairo,cairo"}
-
-    setup(
-        app=APP,
-        data_files=DATA_FILES,
-        options={'py2app': OPTIONS},
-        setup_requires=['py2app'],
-        )
-
 def default_build():
     '''Default Build.'''
-    from distutils.core import setup
-    from glob import glob
 
-    desktop_files = glob("share/*.desktop")
-    form_files = glob("forms/*.x?l")
-    image_files = glob("images/*")
-    image_files.append("d-rats2.ico")
-    image_files.append("share/d-rats2.xpm")
-    ui_files = glob("ui/*")
-    _locale_files = glob("locale/*/LC_MESSAGES/D-RATS.mo")
-    _man_files = glob("share/*.1")
+    print('Creating d_rats/setup_version.py')
+    with open('d_rats/setup_version.py', 'w') as version_file:
+        version_file.write("'''Setup Version.'''\n")
+        version_file.write("# This file generated by python -m build\n")
+        version_file.write('SETUP_VERSION = "%s"\n' % DRATS_VERSION)
+        print('Created d_rats/setup_version.py')
 
-    os.system("make -C libexec")
+    data_files = []
+    system("make -C libexec clean")
+    system("make -C libexec")
+    bin_lzhuf = join('libexec', 'lzhuf')
+    if not exists(bin_lzhuf):
+        bin_lzhuf += ".exe"
+    data_files.append(('/usr/share/d-rats/libexec', [bin_lzhuf]))
 
-    man_files = []
-    for fname in _man_files:
-        os.system("gzip -c %s > %s" % (fname, fname + ".gz"))
-        man_files.append(fname + ".gz")
+    section_files = glob("share/*.desktop")
+    data_files.append(('share/applications', section_files))
 
-    locale_files = []
-    for fname in _locale_files:
-        locale_files.append(("/usr/share/d-rats/%s" % os.path.dirname(fname),
-                             [fname]))
+    data_files.append(('share/icons', ['share/d-rats2.xpm']))
 
-    print(("LOC: %s" % str(ui_files)))
+    section_files = glob("forms/*.x?l")
+    data_files.append(('share/d-rats/forms', section_files))
 
-    setup(
-        name="d-rats",
-        description="D-RATS",
-        long_description="A communications tool for D-STAR",
-        author="Dan Smith, KK7DS until v0.3.3, then Maurizio Andreotti IZ2LXI ",
-        author_email="iz2lxi@yahoo.it",
-        packages=["d_rats", "d_rats.map", "d_rats.ui", "d_rats.sessions"],
-        version=DRATS_VERSION,
-        scripts=["d-rats.py", "d-rats_repeater.py"],
-        data_files=[('/usr/share/applications', desktop_files),
-                    ('/usr/share/icons', ["share/d-rats2.xpm"]),
-                    ('/usr/share/d-rats/forms', form_files),
-                    ('/usr/share/d-rats/images', image_files),
-                    ('/usr/share/d-rats/ui', ui_files),
-                    ('/usr/share/d-rats/libexec', ["libexec/lzhuf"]),
-                    ('/usr/share/man/man1', man_files),
-                    ('/usr/share/doc/d-rats', ['COPYING']),
-                    ] + locale_files)
+    section_files = glob("images/*")
+    section_files.append("d-rats2.ico")
+    section_files.append("share/d-rats2.xpm")
+    data_files.append(('share/d-rats/images', section_files))
 
-if sys.platform == "darwin":
-    macos_build()
-elif sys.platform == "win32":
-    win32_build()
-else:
-    default_build()
+    ui_files = ['ui/addport.glade', 'ui/mainwindow.glade']
+
+    data_files.append(('share/d-rats/ui', ui_files))
+
+    system('towncrier build --yes')
+
+    section_files = ['COPYING']
+    doc_srcs = ['changelog', 'NEWS.rst']
+    for file_name in doc_srcs:
+        file_gz = file_name + ".gz"
+        system("gzip -c %s > %s" % (file_name, file_gz))
+        section_files.append(file_gz)
+    data_files.append(('share/doc/d-rats/', section_files))
+
+    section_files = []
+    man_src_files = glob("share/*.1")
+    for file_name in man_src_files:
+        file_gz = file_name + ".gz"
+        system("gzip -c %s > %s" % (file_name, file_gz))
+        section_files.append(file_gz)
+    data_files.append(('share/man/man1', section_files))
+
+    locale_po_files = glob("locale/*/LC_MESSAGES/D-RATS.po")
+    for file_name in locale_po_files:
+        locale_dir = dirname(file_name)
+        command = "msgfmt -o %s/D-RATS.mo %s/D-RATS" % (locale_dir, locale_dir)
+        system(command)
+
+    locale_mo_files = glob("locale/*/LC_MESSAGES/D-RATS.mo")
+    mo_prefix = 'share/'
+    for file_name in locale_mo_files:
+        data_files.append((mo_prefix + dirname(file_name), [file_name]))
+
+    setup(scripts=['d-rats.py', 'd-rats_repeater.py'],
+          data_files=data_files)
+
+default_build()


### PR DESCRIPTION
Now use python -m build and towncrier for building packages.

MANIFEST.in:
  Updated list of files.

NEWS.rst:
  Start of NEWS.rst.

README.md:
  Update for new packaging documentation.

changelog:
  Note the change to NEWs.rst based on towncrier.

changes/: (new)
  Changes for a future NEWS.rst generated for a release.

libexec/makefile:
  Fix make clean to work on most platforms.

msys2_packages.sh: (new)
  Script to help install packages on msys2 for Microsoft Windows.

newsfragments/.gitignore: (new)
  Directory that towncrier said to create apparently used
  just for temporary files.

pyproject.toml: (new)
  Description file for d-rats project.

requirements.txt: (new)
  Needed packages for building python packages in a virtual
  envrionment.

setup.cfg:
  Comment out until disto packaging is figured out.

setup.py:
  Change for using python -m build, and to make
  sure that NEWS.rst, lzhuf, and message catalogs.