### PR TITLE
fix(tests) Add pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You will need to install a Python 3 interpreter.
 
 John Malmberg will not be installing or testing any Python interpreter
 that requires a paid license for commercial work, even if that license allows
-free non-commercial use.  Some Pythons distributions for Microsoft Windows
+free non-commercial use.  Some Pythons distributions for Desktop platforms
 have this restriction.
 
 ---
@@ -137,14 +137,32 @@ The installation steps are quite easy (assuming one has all the needed python
 libs installed):
 
 Debian packages needed for running or development.
+
+Below if you are not in a locale that is english, you will need the aspell-
+variant dictionary for your locale.  Developers may need apell- variant
+dictionaries for all locales that D-rats has message files for.
+
 The python2 packages are only needed for running the stable python2 version
 of d-rats.
+
+Anti-x 19 Can run the older d-rats using Python 2, and the newer D-rats using
+Python 3
 
 aspell aspell-en bandit(future) gedit python2 python3 pylint pylint3 glade
 python-gobject python-gtk2 python3-gi python-glade2 python-serial
 python3-serial python-libxml2 python-libxslt1 python3-lxml python-simplejson
 python-feedparser python-flask python-gevent python3-gevent python-socketio
 python3-greenlet python-ipykernel python-gi-cairo python-geopy python-pil
+python3-simplejson python3-feedparser python3-flask python3-ipykernel
+python3-gi-cairo python3-geopy python3-pil shellcheck
+
+Anti-x 22 Can not run the older D-rats on Python2.
+
+aspell aspell-en bandit(future) gedit python3 pylint pylint3 glade
+python3-gi python3-serial python3-lxml python3-simplejson
+python3-feedparser python3-flask python3-gevent python3-greenlet
+python3-ipykernel python3-gi-cairo python3-geopy python3-pil
+python3-pip shellcheck
 
 For msys2, the script msys2_packages.sh will hopefully install all the
 needed packages.  The "dev" parameter is passed to install extra images
@@ -187,6 +205,13 @@ to add more languages you have to build the message catalogs.
 
 See <https://github.com/wb8tyw/D-Rats/wiki/Internationalization> for the
 easy steps for building and maintaining the message catalogs.
+
+### Development of D-rats
+
+D-rats is currently hosted on github.com as a git repository.
+
+See the https://github.com/wb8tyw/D-Rats for the most current procedures
+for submitting PRs.
 
 ### Build for INSTALL ON LINUX and MSYS2 and others
 

--- a/tests/pre-commit
+++ b/tests/pre-commit
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# First part based on the pre-commit sample
+set -ue
+
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii) || true
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test "$(git diff --cached --name-only --diff-filter=A -z "$against" |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c)" != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached "$against" --
+
+CHANGED_FILES=$(git diff --name-only --cached --diff-filter=ACMR)
+export CHANGED_FILES
+
+rc=0
+for check_script in tests/pre-commit_d/*; do
+    if ! "${check_script}"; then
+        (( rc=rc+PIPESTATUS[0] ))
+    fi
+done
+exit "$rc"

--- a/tests/pre-commit_d/pylint_check.sh
+++ b/tests/pre-commit_d/pylint_check.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -ue
+
+# Default list of files to lint
+: "${CHANGED_FILES:=}"
+if [ -z "$CHANGED_FILES" ]; then
+  # Nothing to do
+  exit 0
+fi
+
+# Default output
+: "${PYLINT_OUT:=pylint.log}"
+# Extra Pylint Options
+: "${PYLINT_OPTS:=}"
+# Default directory to start check
+: "${BASE_DIR:=.}"
+
+# Default checking
+# pylint_rc="$(find "${BASE_DIR}" -name pylint.rc -print -quit)"
+
+# Now search for all python files
+rc=0
+pushd "${BASE_DIR}" > /dev/null || exit 1
+
+  rm -f "${PYLINT_OUT}"
+
+  # Template to allow other tools to parse the output
+  tmpl="{path}:{line}: pylint-{symbol}: {msg}"
+
+  pylint="$(command -v pylint)"
+  if [ -z "${pylint}" ]; then
+    echo "pylint not found"
+    exit 1
+  fi
+
+  for script_file in ${CHANGED_FILES}; do
+
+    IFS=" " read -r -a pylint_cmd <<< "${pylint} ${PYLINT_OPTS} ${script_file}"
+    if file "$script_file" | grep -q -e 'Python script'; then
+      if ! python "${pylint_cmd[@]}" --msg-template "${tmpl}" >> \
+        "${PYLINT_OUT}" 2>&1; then
+        (( rc=rc+PIPESTATUS[0] ))
+      fi
+    fi
+  done
+  if [ -e "${PYLINT_OUT}" ]; then
+    grep ':' "${PYLINT_OUT}"
+  fi
+popd > /dev/null || exit 1
+exit "${rc}"


### PR DESCRIPTION
Add a pre-commit hook and a pylint check.
This is to catch errors that were missed in testing before
you commit a change.

More checks will be added in the future.

Use 'cp tests/pre-commit .git/hooks' to activate.
Make sure that you have execute accss to the file, on Linux
that should already be the case.

tests/pre-commit: (New file)
  A pre-commit hook to be copied into .git/hooks

tests/pylint_check.sh:
  A pylint checking script