### PR TITLE
fix(xmllint) Add xmllint checklist

### DIFF
--- a/.github/workflows/xmllint.yml
+++ b/.github/workflows/xmllint.yml
@@ -1,0 +1,31 @@
+name: xmllint
+
+# Always run on Pull Requests
+on:
+  pull_request:
+
+jobs:
+  pylint:
+    name: Run xmllint
+    # Oddly ubuntu-latest is older than 22.04 right now.
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install core packages
+        run: |
+          ./tests/install_xmllint_ubuntu.sh
+      - name: Pull via git
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.sha }}
+      - name: Show git diff
+        run: |
+           git diff --name-only ${{ github.event.pull_request.base.sha }}
+      - name: Do the pylint
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          changed="$(git diff --name-only $base_sha)"
+          export CHANGED_FILES="$changed"
+          ./tests/pre-commit_d/xmllint_check.sh

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ python3-serial python-libxml2 python-libxslt1 python3-lxml python-simplejson
 python-feedparser python-flask python-gevent python3-gevent python-socketio
 python3-greenlet python-ipykernel python-gi-cairo python-geopy python-pil
 python3-simplejson python3-feedparser python3-flask python3-ipykernel
-python3-gi-cairo python3-geopy python3-pil shellcheck codespell
+python3-gi-cairo python3-geopy python3-pil shellcheck codespell libxml2-utils
+aspell-it
 
 Anti-x 22 Can not run the older D-rats on Python2.
 
@@ -162,7 +163,7 @@ aspell aspell-en bandit(future) gedit python3 pylint pylint3 glade
 python3-gi python3-serial python3-lxml python3-simplejson
 python3-feedparser python3-flask python3-gevent python3-greenlet
 python3-ipykernel python3-gi-cairo python3-geopy python3-pil
-python3-pip shellcheck codespell
+python3-pip shellcheck codespell libxml2-utils aspell-it
 
 For msys2, the script msys2_packages.sh will hopefully install all the
 needed packages.  The "dev" parameter is passed to install extra images

--- a/msys2_packages.sh
+++ b/msys2_packages.sh
@@ -15,10 +15,12 @@ pacman -Syu --noconfirm \
 
 if [[ "$1" == dev* ]]; then
   # packaging
+  # no aspell-it dictionary at this time.
   pacman -Syu --noconfirm \
     "${mingw}-gcc" \
     "${mingw}-glade" \
     "${mingw}-make" \
+    "${mingw}-python-codespell" \
     "${mingw}-python-pylint" \
     "${mingw}-python-setuptools" \
     "${mingw}-python-virtualenv"

--- a/tests/install_xmllint_ubuntu.sh
+++ b/tests/install_xmllint_ubuntu.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This is for use in a dockerfile or a github action to make sure
+# that the required packages are installed.
+
+set -uex
+
+# Need to disable are-you-sure prompts during the installs
+DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND
+# echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/no-prompt
+# echo "APT::Install-Recommends \"false\";" > \
+#    /etc/apt/apt.conf.d/no-recommends
+
+# Update to current and add packages
+sudo -S -E apt-get --assume-yes update
+sudo -S -E apt-get --assume-yes install aptitude
+sudo -S -E aptitude --assume-yes safe-upgrade
+sudo -S -E apt-get --assume-yes install \
+    file \
+    git \
+    grep \
+    libxml2-utils

--- a/tests/pre-commit_d/codespell_check.sh
+++ b/tests/pre-commit_d/codespell_check.sh
@@ -23,7 +23,7 @@ pushd "${BASE_DIR}" > /dev/null || exit 1
   codespell="$(command -v codespell)"
   if [ -z "${codespell}" ]; then
     echo "codespell not found"
-    exit 1
+    exit 0
   fi
 
   for script_file in ${CHANGED_FILES}; do

--- a/tests/pre-commit_d/pylint_check.sh
+++ b/tests/pre-commit_d/pylint_check.sh
@@ -31,7 +31,7 @@ pushd "${BASE_DIR}" > /dev/null || exit 1
   pylint="$(command -v pylint)"
   if [ -z "${pylint}" ]; then
     echo "pylint not found"
-    exit 1
+    exit 0
   fi
 
   for script_file in ${CHANGED_FILES}; do

--- a/tests/pre-commit_d/shellcheck_check.sh
+++ b/tests/pre-commit_d/shellcheck_check.sh
@@ -32,7 +32,7 @@ pushd "${BASE_DIR}" > /dev/null || exit 1
   shellcheck="$(command -v shellcheck)"
   if [ -z "${shellcheck}" ]; then
     echo "shellcheck not found"
-    exit 1
+    exit 0
   fi
 
   for script_file in ${CHANGED_FILES}; do

--- a/tests/pre-commit_d/xmllint_check.sh
+++ b/tests/pre-commit_d/xmllint_check.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -ue
+
+# Default list of files to lint
+: "${CHANGED_FILES:=}"
+if [ -z "$CHANGED_FILES" ]; then
+  # Nothing to do
+  exit 0
+fi
+
+# Default output
+: "${XMLLINT_OUT:=xmllint.log}"
+# Default directory to start check
+: "${BASE_DIR:=.}"
+
+# Now search for all shell script files
+rc=0
+pushd "${BASE_DIR}" > /dev/null || exit 1
+
+  rm -f "${XMLLINT_OUT}"
+
+  xmllint="$(command -v xmllint)"
+  if [ -z "${xmllint}" ]; then
+    echo "xmllint not found"
+    exit 0
+  fi
+
+  for script_file in ${CHANGED_FILES}; do
+
+    IFS=" " read -r -a xmllint_cmd <<< \
+        "${xmllint} --noout ${script_file}"
+    if file "$script_file" | grep -q -E '(XML|HTML)\s.*document'; then
+      if ! "${xmllint_cmd[@]}" >> "${XMLLINT_OUT}" 2>&1; then
+        (( rc=rc+PIPESTATUS[0] ))
+      fi
+    fi
+  done
+  if [ "$rc" -ne 0 ] && [ -e "${XMLLINT_OUT}" ]; then
+    if ! grep ':' "${XMLLINT_OUT}"; then
+      cat "${XMLLINT_OUT}"
+    fi
+  fi
+popd > /dev/null || exit 1
+exit "${rc}"


### PR DESCRIPTION
tests/install_xmllint_ubuntu.sh: (new)
  Script to install xmllint for a github action.

tests/pre-commit_d/xmllint_check.sh: (new)
  Git hook to scan for xml files.

README.md:
  add libxml2-utils to list of packages

msys2_packages.sh:
  Add codespell to development packages

tests/pre-commit_d/codespell_check.sh:
tests/pre-commit_d/pylint_check.sh:
tests/pre-commit_d/shellcheck_check.sh:
  Do not fail pre-commmit if linting tool is not present.